### PR TITLE
Add build-time GitHub embeds

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -52,5 +52,6 @@
 	</main>
 	{% include "layouts/partials/theme-init-script.njk" %}
 	{% include "layouts/partials/theme-preview-script.njk" %}
+	<script src="/assets/js/copy.js" defer></script>
 </body>
 </html>

--- a/_includes/layouts/partials/theme-styles.njk
+++ b/_includes/layouts/partials/theme-styles.njk
@@ -1,5 +1,6 @@
 <link rel="stylesheet" href="https://unpkg.com/tachyons@4.12.0/css/tachyons.min.css"/>
 <link rel="stylesheet" href="/assets/css/code-embeds.css"/>
+<link rel="stylesheet" href="/assets/css/highlight-github.css"/>
 <style>
 	html.theme {
 		transition: background-color {{ transitionDuration }} {{ transitionTimingFunction }}, color {{ transitionDuration }} {{ transitionTimingFunction }};

--- a/_includes/layouts/partials/theme-styles.njk
+++ b/_includes/layouts/partials/theme-styles.njk
@@ -1,4 +1,5 @@
 <link rel="stylesheet" href="https://unpkg.com/tachyons@4.12.0/css/tachyons.min.css"/>
+<link rel="stylesheet" href="/assets/css/code-embeds.css"/>
 <style>
 	html.theme {
 		transition: background-color {{ transitionDuration }} {{ transitionTimingFunction }}, color {{ transitionDuration }} {{ transitionTimingFunction }};

--- a/assets/css/code-embeds.css
+++ b/assets/css/code-embeds.css
@@ -1,0 +1,79 @@
+.gh-embed {
+  border: 1px solid var(--gh-border, #d0d7de);
+  border-radius: 6px;
+  overflow: hidden;
+  margin: 1.25rem 0;
+  background: var(--gh-bg, #fff);
+}
+.gh-embed--dark {
+  --gh-bg: #0d1117;
+  --gh-fg: #c9d1d9;
+  --gh-border: #30363d;
+  --gh-meta-bg: #161b22;
+  --gh-link: #58a6ff;
+  color: var(--gh-fg);
+}
+.gh-embed--light {
+  --gh-bg: #fff;
+  --gh-fg: #24292f;
+  --gh-border: #d0d7de;
+  --gh-meta-bg: #f6f8fa;
+  --gh-link: #0969da;
+  color: var(--gh-fg);
+}
+
+.gh-embed__meta {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  background: var(--gh-meta-bg);
+  font: 12px/1.4 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  border-bottom: 1px solid var(--gh-border);
+}
+.gh-embed__meta a {
+  color: var(--gh-link);
+  text-decoration: none;
+}
+.gh-embed__file {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.gh-embed__raw {
+  margin-left: auto;
+}
+
+.gh-embed__copy {
+  margin-left: 0.75rem;
+  border: 1px solid var(--gh-border);
+  background: transparent;
+  color: inherit;
+  font: 12px/1 monospace;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.gh-embed__pre {
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  overflow-x: auto;
+}
+.gh-embed__ol {
+  list-style: decimal;
+  margin: 0;
+  padding-left: 2.5rem;
+  white-space: pre;
+}
+.gh-embed__ol > li {
+  line-height: 1.4;
+}
+.gh-embed__ol > li > code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  background: none;
+  padding: 0;
+}

--- a/assets/css/code-embeds.css
+++ b/assets/css/code-embeds.css
@@ -1,79 +1,132 @@
 .gh-embed {
-  border: 1px solid var(--gh-border, #d0d7de);
+  --gh-bg: #fff;
+  --gh-fg: #24292f;
+  --gh-border: #d0d7de;
+  --gh-meta-bg: #f6f8fa;
+  --gh-link: #0969da;
+  --gh-line-number: #57606a;
+  --gh-code-bg: #f6f8fa;
+  border: 1px solid var(--gh-border);
   border-radius: 6px;
   overflow: hidden;
   margin: 1.25rem 0;
-  background: var(--gh-bg, #fff);
+  background: var(--gh-bg);
+  color: var(--gh-fg);
+  box-shadow: 0 1px 0 rgba(27, 31, 36, 0.04);
+  font: 12px/1 ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
 }
+
 .gh-embed--dark {
   --gh-bg: #0d1117;
   --gh-fg: #c9d1d9;
   --gh-border: #30363d;
   --gh-meta-bg: #161b22;
   --gh-link: #58a6ff;
-  color: var(--gh-fg);
-}
-.gh-embed--light {
-  --gh-bg: #fff;
-  --gh-fg: #24292f;
-  --gh-border: #d0d7de;
-  --gh-meta-bg: #f6f8fa;
-  --gh-link: #0969da;
-  color: var(--gh-fg);
+  --gh-line-number: #8b949e;
+  --gh-code-bg: #0d1117;
+  box-shadow: 0 0 0 1px rgba(240, 246, 252, 0.04);
 }
 
 .gh-embed__meta {
   display: flex;
-  gap: 0.75rem;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
   align-items: center;
-  justify-content: space-between;
   padding: 0.5rem 0.75rem;
   background: var(--gh-meta-bg);
   font: 12px/1.4 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
   border-bottom: 1px solid var(--gh-border);
 }
+
 .gh-embed__meta a {
   color: var(--gh-link);
   text-decoration: none;
 }
+
+.gh-embed__meta a:hover,
+.gh-embed__meta a:focus {
+  text-decoration: underline;
+}
+
 .gh-embed__file {
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 100%;
 }
-.gh-embed__raw {
+
+.gh-embed__actions {
   margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .gh-embed__copy {
-  margin-left: 0.75rem;
   border: 1px solid var(--gh-border);
-  background: transparent;
+  background: rgba(175, 184, 193, 0.12);
   color: inherit;
-  font: 12px/1 monospace;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
+  font: 12px/1 ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  padding: 0.25rem 0.65rem;
+  border-radius: 6px;
   cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.gh-embed__copy:hover,
+.gh-embed__copy:focus {
+  background: rgba(175, 184, 193, 0.24);
+  border-color: rgba(27, 31, 36, 0.2);
+}
+
+.gh-embed--dark .gh-embed__copy {
+  background: rgba(110, 118, 129, 0.12);
+  border-color: rgba(110, 118, 129, 0.4);
+}
+
+.gh-embed--dark .gh-embed__copy:hover,
+.gh-embed--dark .gh-embed__copy:focus {
+  background: rgba(110, 118, 129, 0.24);
+  border-color: rgba(240, 246, 252, 0.3);
 }
 
 .gh-embed__pre {
   margin: 0;
-  padding: 0.5rem 0.75rem;
-  overflow-x: auto;
+  padding: 0.5rem 0;
+  overflow: auto;
+  background: var(--gh-code-bg);
 }
+
 .gh-embed__ol {
-  list-style: decimal;
   margin: 0;
-  padding-left: 2.5rem;
-  white-space: pre;
-}
-.gh-embed__ol > li {
-  line-height: 1.4;
-}
-.gh-embed__ol > li > code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-  font-size: 12px;
-  background: none;
   padding: 0;
+  list-style: none;
+  min-width: 100%;
+  color: inherit;
+}
+
+.gh-embed__ol > li {
+  display: grid;
+  grid-template-columns: 2.4rem minmax(0, 1fr);
+  column-gap: 0.6rem;
+  align-items: stretch;
+  padding: 0.05rem 0.9rem 0.05rem 0.6rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.gh-embed__ol > li::before {
+  content: attr(value);
+  text-align: right;
+  color: var(--gh-line-number);
+  padding-right: 0.2rem;
+  user-select: none;
+}
+
+.gh-embed__ol > li > code {
+  display: block;
+  white-space: pre;
+  color: inherit;
 }

--- a/assets/css/highlight-github.css
+++ b/assets/css/highlight-github.css
@@ -1,0 +1,55 @@
+/* GitHub-inspired highlight.js theme */
+.hljs {
+  color: #24292f;
+  background: transparent;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #6a737d;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-literal,
+.hljs-subst {
+  color: #d73a49;
+}
+
+.hljs-number,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-tag,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class,
+.hljs-regexp,
+.hljs-deletion {
+  color: #005cc5;
+}
+
+.hljs-doctag,
+.hljs-string,
+.hljs-title,
+.hljs-section,
+.hljs-addition,
+.hljs-attribute,
+.hljs-built_in,
+.hljs-bullet,
+.hljs-code,
+.hljs-symbol {
+  color: #22863a;
+}
+
+.hljs-type,
+.hljs-class .hljs-title {
+  color: #6f42c1;
+}
+
+.hljs-strong {
+  font-weight: 600;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}

--- a/assets/js/copy.js
+++ b/assets/js/copy.js
@@ -1,0 +1,17 @@
+document.addEventListener("click", (event) => {
+  const button = event.target.closest("[data-clipboard]");
+  if (!button) return;
+  const embed = button.closest(".gh-embed");
+  if (!embed) return;
+  const content = embed.querySelectorAll(".gh-embed__ol > li > code");
+  const text = Array.from(content)
+    .map((node) => node.textContent)
+    .join("\n");
+  if (!text) return;
+  void navigator.clipboard?.writeText(text);
+  const original = button.textContent;
+  button.textContent = "Copied!";
+  window.setTimeout(() => {
+    button.textContent = original || "Copy";
+  }, 1200);
+});

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -164,6 +164,7 @@ export default function (eleventyConfig) {
 			}
 
 			const language = guessLanguageByExt(meta.filePath);
+			const normalizedLanguage = typeof language === "string" ? language.toLowerCase().replace(/[^a-z0-9-]+/g, "") : "";
 			let highlighted;
 			try {
 				highlighted = hljs.highlight(code, { language }).value;
@@ -176,11 +177,13 @@ export default function (eleventyConfig) {
 				.map((line, index) => {
 					const content = line.trim().length ? line : " ";
 					const lineNumber = (meta.start || 1) + index;
-					return `<li value="${lineNumber}"><code>${content}</code></li>`;
+					const languageAttr = normalizedLanguage ? ` class="language-${normalizedLanguage}"` : "";
+					return `<li value="${lineNumber}"><code${languageAttr}>${content}</code></li>`;
 				})
 				.join("\n");
 
 			const theme = style || "light";
+			const languageClass = normalizedLanguage ? ` language-${normalizedLanguage}` : "";
 
 			return `
 <div class="gh-embed gh-embed--${theme}">
@@ -188,15 +191,17 @@ export default function (eleventyConfig) {
 		<a class="gh-embed__file" href="${meta.web}" target="_blank" rel="noopener noreferrer">
 			${meta.filePath}
 		</a>
-		<a class="gh-embed__raw" href="${meta.raw}" target="_blank" rel="noopener noreferrer">view raw</a>
-		<button class="gh-embed__copy" data-clipboard>Copy</button>
+		<div class="gh-embed__actions">
+			<a class="gh-embed__raw" href="${meta.raw}" target="_blank" rel="noopener noreferrer">view raw</a>
+			<button class="gh-embed__copy" data-clipboard>Copy</button>
+		</div>
 	</div>
-	<pre class="gh-embed__pre hljs">
+	<pre class="gh-embed__pre hljs${languageClass}">
 		<ol class="gh-embed__ol">${numbered}</ol>
 	</pre>
 </div>`;
-		}
-	);
+			}
+		);
 
 	eleventyConfig.addFilter("readableDate", (dateValue, locale = "en-US") => {
 		if (!dateValue) return "";

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -2,6 +2,9 @@
 import eleventyNavigationPlugin from "@11ty/eleventy-navigation";
 // 11ty Img
 import { eleventyImageTransformPlugin } from "@11ty/eleventy-img";
+import EleventyFetch from "@11ty/eleventy-fetch";
+import hljs from "highlight.js";
+import path from "node:path";
 
 // Bake our own Markdown anchors
 import MarkdownIt from "markdown-it";
@@ -12,6 +15,64 @@ import yaml from "js-yaml";
 import excerpt from "./lib/excerpt.js";
 
 const OG_FORCE_ENV = process.env.OG_FORCE === "true";
+
+const parseBlobUrl = (githubBlobUrl) => {
+	const url = new URL(githubBlobUrl);
+	const parts = url.pathname.split("/").filter(Boolean);
+	if (parts[2] !== "blob") throw new Error("URL must be a GitHub blob URL");
+	const [user, repo, , branch, ...fileParts] = parts;
+	const filePath = fileParts.join("/");
+	const rangeHash = (url.hash || "").replace(/^#/, "");
+	let start = null;
+	let end = null;
+	if (rangeHash.startsWith("L")) {
+		const [first, last] = rangeHash.split("-").map((part) => part.replace(/^L/, ""));
+		start = parseInt(first, 10);
+		end = last ? parseInt(last, 10) : start;
+	}
+	const raw = `https://raw.githubusercontent.com/${user}/${repo}/${branch}/${filePath}`;
+	return { user, repo, branch, filePath, raw, web: githubBlobUrl, start, end };
+};
+
+const escapeHtml = (value) =>
+	value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;");
+
+const guessLanguageByExt = (filePath) => {
+	const ext = path.extname(filePath).toLowerCase().replace(".", "");
+	const map = {
+		js: "javascript",
+		mjs: "javascript",
+		cjs: "javascript",
+		ts: "typescript",
+		tsx: "tsx",
+		jsx: "jsx",
+		json: "json",
+		yml: "yaml",
+		yaml: "yaml",
+		sh: "bash",
+		zsh: "bash",
+		bash: "bash",
+		swift: "swift",
+		py: "python",
+		rb: "ruby",
+		go: "go",
+		rs: "rust",
+		php: "php",
+		java: "java",
+		kt: "kotlin",
+		css: "css",
+		scss: "scss",
+		html: "xml",
+		xml: "xml",
+		md: "markdown",
+		txt: "plaintext",
+	};
+	return map[ext] || "plaintext";
+};
 
 const slugify = (value) =>
 	encodeURIComponent(String(value).trim().toLowerCase().replace(/\s+/g, "-"));
@@ -87,6 +148,55 @@ export default function (eleventyConfig) {
 
 	// Copy static assets straight through to the build output
 	eleventyConfig.addPassthroughCopy("assets");
+
+	eleventyConfig.addAsyncShortcode(
+		"github",
+		async function (url, style = "light") {
+			const meta = parseBlobUrl(url);
+
+			const fetched = await EleventyFetch(meta.raw, { duration: "1d", type: "text" });
+			const source = typeof fetched === "string" ? fetched : String(fetched);
+
+			let code = source;
+			if (meta.start && meta.end) {
+				const lines = source.split("\n");
+				code = lines.slice(meta.start - 1, meta.end).join("\n");
+			}
+
+			const language = guessLanguageByExt(meta.filePath);
+			let highlighted;
+			try {
+				highlighted = hljs.highlight(code, { language }).value;
+			} catch {
+				highlighted = escapeHtml(code);
+			}
+
+			const numbered = highlighted
+				.split("\n")
+				.map((line, index) => {
+					const content = line.trim().length ? line : " ";
+					const lineNumber = (meta.start || 1) + index;
+					return `<li value="${lineNumber}"><code>${content}</code></li>`;
+				})
+				.join("\n");
+
+			const theme = style || "light";
+
+			return `
+<div class="gh-embed gh-embed--${theme}">
+	<div class="gh-embed__meta">
+		<a class="gh-embed__file" href="${meta.web}" target="_blank" rel="noopener noreferrer">
+			${meta.filePath}
+		</a>
+		<a class="gh-embed__raw" href="${meta.raw}" target="_blank" rel="noopener noreferrer">view raw</a>
+		<button class="gh-embed__copy" data-clipboard>Copy</button>
+	</div>
+	<pre class="gh-embed__pre hljs">
+		<ol class="gh-embed__ol">${numbered}</ol>
+	</pre>
+</div>`;
+		}
+	);
 
 	eleventyConfig.addFilter("readableDate", (dateValue, locale = "en-US") => {
 		if (!dateValue) return "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,12 @@
         "slugify": "^1.6.6"
       },
       "devDependencies": {
+        "@11ty/eleventy-fetch": "^5.1.0",
         "@fontsource/inter": "^5.0.18",
         "@fontsource/lexend": "^5.0.18",
         "@resvg/resvg-js": "^2.6.0",
         "gray-matter": "^4.0.3",
+        "highlight.js": "^11.11.1",
         "satori": "^0.10.14",
         "satori-html": "^0.3.2"
       }
@@ -1678,6 +1680,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/htmlparser2": {

--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
     "slugify": "^1.6.6"
   },
   "devDependencies": {
+    "@11ty/eleventy-fetch": "^5.1.0",
     "@fontsource/inter": "^5.0.18",
     "@fontsource/lexend": "^5.0.18",
     "@resvg/resvg-js": "^2.6.0",
     "gray-matter": "^4.0.3",
+    "highlight.js": "^11.11.1",
     "satori": "^0.10.14",
     "satori-html": "^0.3.2"
   }


### PR DESCRIPTION
## Summary
- register the `{% github %}` shortcode for all template engines and normalize fetched content
- add GitHub-style embed chrome, highlight.js theme, copy button tweaks, and tighter gutters
- document shortcode usage in the README

## Testing
- npm run build