### PR TITLE
feat(pagination): add build-time pagination to home page

### DIFF
--- a/_data/sidebarNav.yaml
+++ b/_data/sidebarNav.yaml
@@ -7,6 +7,8 @@
       value: /
     - type: startsWith
       value: /posts/
+    - type: startsWith
+      value: /page/
 - id: series
   label: Series
   url: /series/

--- a/_includes/components/post-list.njk
+++ b/_includes/components/post-list.njk
@@ -1,8 +1,8 @@
-{% macro renderPostList(items=[], emptyMessage='No entries found.') %}
+{% macro renderPostList(items=[], emptyMessage='No entries found.', reverse=true) %}
   {% set list = items or [] %}
   {% if list | length %}
     <div class="flex flex-column">
-      {% for item in list | reverse %}
+      {% for item in (list | reverse if reverse else list) %}
         <article class="mb4 pb4 bb b--black-10">
           <h2 class="f3 lh-title mb2">
             <a class="link dim theme-text" href="{{ item.url | url }}">{{ item.data.title }}</a>

--- a/src/index.njk
+++ b/src/index.njk
@@ -1,12 +1,33 @@
 ---
 layout: layouts/home.njk
 title: Home
-permalink: /
+pagination:
+  data: collections.posts
+  size: 10 # posts per page
+  reverse: true
+permalink: "{% if pagination.pageNumber == 0 %}/{% else %}/page/{{ pagination.pageNumber + 1 }}/{% endif %}"
+eleventyComputed:
+  title: "{% if pagination.pageNumber == 0 %}Home{% else %}Home · Page {{ pagination.pageNumber + 1 }}{% endif %}"
 ---
 
 {% from "components/post-list.njk" import renderPostList %}
 
 <section class="mw7 center">
   <h1 class="f3 f2-ns lh-title mt0 mb0">Latest Posts</h1>
-  {{ renderPostList(collections.posts, "No posts published yet. Check back soon.") | safe }}
+  {{ renderPostList(pagination.items, "No posts published yet. Check back soon.", false) | safe }}
+  {% if pagination.pages | length > 1 %}
+    <nav class="flex justify-between items-center f6 theme-midtone mt4">
+      <div>
+        {% if pagination.href.previous %}
+          <a class="link dim theme-text" href="{{ pagination.href.previous }}">Previous</a>
+        {% endif %}
+      </div>
+      <div>Page {{ pagination.pageNumber + 1 }} of {{ pagination.pages | length }}</div>
+      <div>
+        {% if pagination.href.next %}
+          <a class="link dim theme-text" href="{{ pagination.href.next }}">Next</a>
+        {% endif %}
+      </div>
+    </nav>
+  {% endif %}
 </section>


### PR DESCRIPTION
## Summary

- Paginate the home page at build time using native 11ty pagination (size: 10)
- Page 1 stays at `/`, subsequent pages at `/page/2/`, `/page/3/`, etc.
- Adds prev/next links and a `Page X of Y` indicator, hidden when only one page exists
- Updates `post-list.njk` with an optional `reverse` parameter (default `true`) so existing callers are unaffected
- Updates the Blog sidebar `activePatterns` to stay active on `/page/` routes

## Test plan

- [x] Build succeeds in development and production
- [x] `/` shows the newest posts
- [x] `/page/2/` is generated once there are more than 10 non-draft posts
- [x] No `/page/1/` route is generated
- [x] Previous/next links point to the correct pages
- [x] Pager is hidden when only one page exists
- [x] Blog nav remains active on paginated home routes
- [x] Tag, series, and drafts pages still order correctly (macro `reverse` default preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)