### PR TITLE
Auto-switch code and GitHub embed themes with runtime theme

### DIFF
--- a/assets/css/code-embeds.css
+++ b/assets/css/code-embeds.css
@@ -33,6 +33,20 @@
   box-shadow: 0 0 0 1px rgba(240, 246, 252, 0.04);
 }
 
+html.theme[data-theme='grape'] .gh-embed:not(.gh-embed--light),
+html.theme[data-theme='deep-blue'] .gh-embed:not(.gh-embed--light),
+html.theme[data-theme='midnight'] .gh-embed:not(.gh-embed--light),
+html.theme[data-theme='charcoal'] .gh-embed:not(.gh-embed--light) {
+  --gh-bg: #0d1117;
+  --gh-fg: #c9d1d9;
+  --gh-border: #30363d;
+  --gh-meta-bg: #161b22;
+  --gh-link: #58a6ff;
+  --gh-line-number: #8b949e;
+  --gh-code-bg: #0d1117;
+  box-shadow: 0 0 0 1px rgba(240, 246, 252, 0.04);
+}
+
 .gh-embed__meta {
   display: flex;
   flex-wrap: wrap;
@@ -105,13 +119,25 @@
   border-color: rgba(27, 31, 36, 0.2);
 }
 
-.gh-embed--dark .gh-embed__copy {
+.gh-embed--dark .gh-embed__copy,
+html.theme[data-theme='grape'] .gh-embed:not(.gh-embed--light) .gh-embed__copy,
+html.theme[data-theme='deep-blue'] .gh-embed:not(.gh-embed--light) .gh-embed__copy,
+html.theme[data-theme='midnight'] .gh-embed:not(.gh-embed--light) .gh-embed__copy,
+html.theme[data-theme='charcoal'] .gh-embed:not(.gh-embed--light) .gh-embed__copy {
   background: rgba(110, 118, 129, 0.12);
   border-color: rgba(110, 118, 129, 0.4);
 }
 
 .gh-embed--dark .gh-embed__copy:hover,
-.gh-embed--dark .gh-embed__copy:focus {
+.gh-embed--dark .gh-embed__copy:focus,
+html.theme[data-theme='grape'] .gh-embed:not(.gh-embed--light) .gh-embed__copy:hover,
+html.theme[data-theme='grape'] .gh-embed:not(.gh-embed--light) .gh-embed__copy:focus,
+html.theme[data-theme='deep-blue'] .gh-embed:not(.gh-embed--light) .gh-embed__copy:hover,
+html.theme[data-theme='deep-blue'] .gh-embed:not(.gh-embed--light) .gh-embed__copy:focus,
+html.theme[data-theme='midnight'] .gh-embed:not(.gh-embed--light) .gh-embed__copy:hover,
+html.theme[data-theme='midnight'] .gh-embed:not(.gh-embed--light) .gh-embed__copy:focus,
+html.theme[data-theme='charcoal'] .gh-embed:not(.gh-embed--light) .gh-embed__copy:hover,
+html.theme[data-theme='charcoal'] .gh-embed:not(.gh-embed--light) .gh-embed__copy:focus {
   background: rgba(110, 118, 129, 0.24);
   border-color: rgba(240, 246, 252, 0.3);
 }
@@ -218,7 +244,15 @@
 }
 
 .gh-embed--dark .gh-embed__toggle:hover,
-.gh-embed--dark .gh-embed__toggle:focus {
+.gh-embed--dark .gh-embed__toggle:focus,
+html.theme[data-theme='grape'] .gh-embed:not(.gh-embed--light) .gh-embed__toggle:hover,
+html.theme[data-theme='grape'] .gh-embed:not(.gh-embed--light) .gh-embed__toggle:focus,
+html.theme[data-theme='deep-blue'] .gh-embed:not(.gh-embed--light) .gh-embed__toggle:hover,
+html.theme[data-theme='deep-blue'] .gh-embed:not(.gh-embed--light) .gh-embed__toggle:focus,
+html.theme[data-theme='midnight'] .gh-embed:not(.gh-embed--light) .gh-embed__toggle:hover,
+html.theme[data-theme='midnight'] .gh-embed:not(.gh-embed--light) .gh-embed__toggle:focus,
+html.theme[data-theme='charcoal'] .gh-embed:not(.gh-embed--light) .gh-embed__toggle:hover,
+html.theme[data-theme='charcoal'] .gh-embed:not(.gh-embed--light) .gh-embed__toggle:focus {
   background: rgba(110, 118, 129, 0.2);
   border-color: rgba(110, 118, 129, 0.5);
   box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.2);

--- a/assets/css/highlight-github.css
+++ b/assets/css/highlight-github.css
@@ -1,19 +1,40 @@
-/* GitHub-inspired highlight.js theme */
+/* GitHub-inspired highlight.js theme with light/dark runtime theme support */
+main {
+  --hljs-fg: #24292f;
+  --hljs-comment: #6a737d;
+  --hljs-keyword: #d73a49;
+  --hljs-value: #005cc5;
+  --hljs-string: #22863a;
+  --hljs-type: #6f42c1;
+}
+
+html.theme[data-theme='grape'] main,
+html.theme[data-theme='deep-blue'] main,
+html.theme[data-theme='midnight'] main,
+html.theme[data-theme='charcoal'] main {
+  --hljs-fg: #c9d1d9;
+  --hljs-comment: #8b949e;
+  --hljs-keyword: #ff7b72;
+  --hljs-value: #79c0ff;
+  --hljs-string: #7ee787;
+  --hljs-type: #d2a8ff;
+}
+
 .hljs {
-  color: #24292f;
+  color: var(--hljs-fg);
   background: transparent;
 }
 
 .hljs-comment,
 .hljs-quote {
-  color: #6a737d;
+  color: var(--hljs-comment);
 }
 
 .hljs-keyword,
 .hljs-selector-tag,
 .hljs-literal,
 .hljs-subst {
-  color: #d73a49;
+  color: var(--hljs-keyword);
 }
 
 .hljs-number,
@@ -25,7 +46,7 @@
 .hljs-selector-class,
 .hljs-regexp,
 .hljs-deletion {
-  color: #005cc5;
+  color: var(--hljs-value);
 }
 
 .hljs-doctag,
@@ -38,12 +59,12 @@
 .hljs-bullet,
 .hljs-code,
 .hljs-symbol {
-  color: #22863a;
+  color: var(--hljs-string);
 }
 
 .hljs-type,
 .hljs-class .hljs-title {
-  color: #6f42c1;
+  color: var(--hljs-type);
 }
 
 .hljs-strong {

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -405,7 +405,7 @@ export default function (eleventyConfig) {
 
   eleventyConfig.addAsyncShortcode(
     'github',
-    async function (url, style = 'light') {
+    async function (url, style = 'auto') {
       const meta = parseBlobUrl(url);
 
       const fetched = await fetchTextWithCacheRecovery(meta.raw, {
@@ -448,7 +448,11 @@ export default function (eleventyConfig) {
         })
         .join('\n');
 
-      const theme = style || 'light';
+      const normalizedStyle =
+        typeof style === 'string' ? style.toLowerCase().trim() : '';
+      const theme = ['light', 'dark'].includes(normalizedStyle)
+        ? normalizedStyle
+        : 'auto';
       const languageClass = normalizedLanguage
         ? ` language-${normalizedLanguage}`
         : '';


### PR DESCRIPTION
### Motivation
- Let code blocks and GitHub embed chrome follow the site's runtime theme instead of being baked to a single compile-time theme, while preserving explicit `light`/`dark` overrides. 
- Provide consistent styling between inline `pre` highlights and `gh` embeds when users switch themes at runtime.

### Description
- Changed the `github` shortcode default to `auto` and normalized `style` inputs so only explicit `light` or `dark` lock the embed, otherwise embeds follow runtime theme (`eleventy.config.js`).
- Reworked `assets/css/highlight-github.css` to use CSS variables for highlight.js colors and added dark overrides keyed to existing dark site themes so syntax colors switch at runtime.
- Extended `assets/css/code-embeds.css` to apply dark embed chrome and control styles when the site `data-theme` is a dark theme, while keeping `.gh-embed--light` and `.gh-embed--dark` explicit classes functional.
- Preserved collapse/copy/toggle behavior and language/line-number markup produced by the shortcode; added selectors that target `.gh-embed:not(.gh-embed--light)` so explicit light-mode embeds remain unaffected.

### Testing
- Ran `npm run build` to validate the changes, but the build failed in this environment due to network fetch errors when the `github` shortcode attempted to fetch remote blob content (`ENETUNREACH`).
- No other automated tests were present or run in this repository; local CSS/JS changes were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8e2ace808323acad23261bb2a644)