### PR TITLE
feat(timeline): add required time field to entries

### DIFF
--- a/CLAUDE.subspace.md
+++ b/CLAUDE.subspace.md
@@ -52,6 +52,7 @@ draft: true     # hidden in production, visible in dev
 ```yaml
 title:          # optional
 date:
+time:           # required — 24-hour HH:MM (e.g. "15:42")
 tags:
   - timeline    # always present (set by timeline/timeline.json)
   - shipped     # green  — something released

--- a/src/timeline.njk
+++ b/src/timeline.njk
@@ -77,7 +77,7 @@ permalink: /timeline/
           <div class="timeline-body-wrap">
             <div class="timeline-topline">
               <span class="timeline-handle">{{ me.profile.name }}</span>
-              <time class="timeline-timestamp" datetime="{{ entry.date | machineDate }}">{{ entry.date | readableDate }}</time>
+              <time class="timeline-timestamp" datetime="{{ entry.date | machineDate }}T{{ entry.data.time }}">{{ entry.date | readableDate }} · {{ entry.data.time }}</time>
             </div>
             {% if entry.data.title %}
               <h2 class="timeline-title"><a href="{{ entry.url | url }}">{{ entry.data.title }}</a></h2>

--- a/timeline/2026-04-14-shipped-timeline.md
+++ b/timeline/2026-04-14-shipped-timeline.md
@@ -1,6 +1,7 @@
 ---
 title: Shipped the timeline page
 date: 2026-04-14
+time: "15:42"
 tags:
   - timeline
   - shipped


### PR DESCRIPTION
## Summary

- Adds a required `time` front matter field (24-hour `HH:MM`) to timeline entries
- UI timestamp now renders as `April 14, 2026 · 15:42`
- `datetime` attribute updated to full ISO local datetime (e.g. `2026-04-14T15:42`)
- Docs updated in `CLAUDE.subspace.md` to reflect `time` as required

## Test plan

- [x] Build passes (`npm run build`)
- [x] Timeline page shows date + time for the existing entry
- [x] New timeline entries with `time` field render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)