### PR TITLE
[codex] add threaded timeline entries and write-up

### DIFF
--- a/CLAUDE.subspace.md
+++ b/CLAUDE.subspace.md
@@ -53,6 +53,7 @@ draft: true     # hidden in production, visible in dev
 title:          # optional
 date: "YYYY-MM-DD" # required; keep quoted so YAML treats it as a string
 time: "HH:MM"      # required; keep quoted, 24-hour HH:MM (e.g. "15:42")
+parent: "/timeline/2026-04-14-example-entry/" # optional; use the target entry's URL path
 tags:
   - timeline    # always present (set by timeline/timeline.json)
   - shipped     # green  — something released
@@ -64,6 +65,7 @@ tags:
 ```
 
 Timeline `date` and `time` values must stay quoted strings. Unquoted YAML dates are parsed as JavaScript `Date` objects before Eleventy collection sorting runs, which can break within-day ordering.
+Timeline parent references use the entry URL path (`page.url`), including the trailing slash.
 
 ## Theme system
 
@@ -77,6 +79,7 @@ Use `var(--accent)` for theme-aware accent color in custom CSS. Use the `theme-t
 
 - **The build validates all internal links.** A link to a page that does not exist fails the build.
 - **The build validates timeline front matter.** `timeline/*.md` entries must quote `date` and `time`.
+- **The build validates timeline parent refs.** `parent` must point at an existing `/timeline/.../` entry URL and may not create cycles.
 - Never add a nav entry to `sidebarNav.yaml` before the target page is built.
 - Never add cross-page links before both pages exist.
 - Always run `npm run build` to verify before committing.

--- a/_includes/components/timeline-entry.njk
+++ b/_includes/components/timeline-entry.njk
@@ -1,0 +1,204 @@
+{%- macro timelineEntryType(entry) -%}
+  {%- set entryType = "default" -%}
+  {%- if "shipped" in (entry.data.tags | default([])) -%}{%- set entryType = "shipped" -%}
+  {%- elif "published" in (entry.data.tags | default([])) -%}{%- set entryType = "published" -%}
+  {%- elif "wip" in (entry.data.tags | default([])) -%}{%- set entryType = "wip" -%}
+  {%- elif "idea" in (entry.data.tags | default([])) -%}{%- set entryType = "idea" -%}
+  {%- elif "thinking" in (entry.data.tags | default([])) -%}{%- set entryType = "thinking" -%}
+  {%- endif -%}
+  {{- entryType -}}
+{%- endmacro %}
+
+{% macro renderTimelineStyles() %}
+  <style>
+    .timeline-entry {
+      display: flex;
+      gap: 0.75rem;
+      margin-bottom: 0.75rem;
+      border-left: 3px solid var(--timeline-color, var(--accent));
+      padding: 0.875rem 1rem;
+      border-radius: 0 0.375rem 0.375rem 0;
+      background: rgba(128,128,128,0.04);
+    }
+
+    /* Color driven by tag */
+    .timeline-entry[data-type="shipped"]    { --timeline-color: #27ae60; }
+    .timeline-entry[data-type="published"]  { --timeline-color: #2980b9; }
+    .timeline-entry[data-type="wip"]        { --timeline-color: #8e44ad; }
+    .timeline-entry[data-type="idea"]       { --timeline-color: #f1c40f; }
+    .timeline-entry[data-type="thinking"]   { --timeline-color: #e67e22; }
+
+    .timeline-entry--compact {
+      padding: 0.75rem 0.875rem;
+      background: rgba(128,128,128,0.03);
+    }
+
+    .timeline-entry--muted {
+      opacity: 0.82;
+    }
+
+    .timeline-dot {
+      width: 0.5rem;
+      height: 0.5rem;
+      border-radius: 50%;
+      background: var(--timeline-color, var(--accent));
+      flex-shrink: 0;
+      margin-top: 0.45rem;
+    }
+
+    .timeline-entry--compact .timeline-dot {
+      width: 0.45rem;
+      height: 0.45rem;
+      margin-top: 0.35rem;
+    }
+
+    .timeline-body-wrap { flex: 1; min-width: 0; }
+
+    .timeline-topline {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      flex-wrap: wrap;
+      gap: 0.2rem 0.75rem;
+      margin-bottom: 0.25rem;
+    }
+    .timeline-handle { font-size: 0.8rem; opacity: 0.5; font-family: monospace; }
+    .timeline-timestamp { font-size: 0.75rem; opacity: 0.45; white-space: nowrap; }
+
+    .timeline-title { font-weight: 600; font-size: 0.9375rem; margin: 0 0 0.375rem; line-height: 1.3; }
+    .timeline-title a { text-decoration: none; }
+    .timeline-title a:hover { text-decoration: underline; }
+
+    .timeline-entry--compact .timeline-title {
+      font-size: 0.9rem;
+      margin-bottom: 0.3rem;
+    }
+
+    .timeline-content { font-size: 0.875rem; line-height: 1.6; }
+    .timeline-content p { margin: 0 0 0.5em; }
+    .timeline-content p:last-child { margin-bottom: 0; }
+
+    .timeline-entry--compact .timeline-content {
+      font-size: 0.8125rem;
+      line-height: 1.55;
+    }
+
+    .timeline-footer { margin-top: 0.6rem; }
+    .timeline-relationships {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.35rem 0.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .timeline-relationship {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3rem;
+      max-width: 100%;
+      border: 1px solid rgba(0, 0, 0, 0.12);
+      border-radius: 999px;
+      padding: 0.15rem 0.55rem;
+      font-size: 0.72rem;
+      line-height: 1.3;
+      text-decoration: none;
+      color: inherit;
+      opacity: 0.7;
+    }
+    .timeline-relationship:hover {
+      opacity: 1;
+      text-decoration: none;
+    }
+    .timeline-relationship__label { opacity: 0.7; }
+    .timeline-tags { display: flex; flex-wrap: wrap; gap: 0.2rem 0.4rem; }
+    .timeline-tags a { font-size: 0.7rem; opacity: 0.5; text-decoration: none; }
+    .timeline-tags a:hover { opacity: 1; text-decoration: underline; }
+
+    .timeline-thread {
+      margin-top: 1.5rem;
+    }
+
+    .timeline-thread__branch + .timeline-thread__branch {
+      margin-top: 1.5rem;
+    }
+
+    .timeline-thread__label {
+      font-size: 0.72rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      opacity: 0.6;
+      margin: 0 0 0.65rem;
+    }
+
+    .timeline-thread__branch--parent .timeline-entry {
+      margin-bottom: 0;
+    }
+
+    .timeline-thread__stack {
+      position: relative;
+      margin-left: 0.35rem;
+      padding-left: 1rem;
+    }
+
+    .timeline-thread__stack::before {
+      content: '';
+      position: absolute;
+      top: 0.35rem;
+      bottom: 0.35rem;
+      left: 0;
+      width: 1px;
+      background: rgba(0, 0, 0, 0.14);
+    }
+
+    .timeline-thread__stack .timeline-entry:last-child {
+      margin-bottom: 0;
+    }
+  </style>
+{% endmacro %}
+
+{% macro renderTimelineEntry(entry, timelineEntries=[], compact=false, showRelationships=true, showTags=true, muted=false) %}
+  {% set entryTags = (entry.data.tags | default([])) | filterTags %}
+  {% set parentEntry = entry | timelineParentEntry(timelineEntries) %}
+  {% set childEntries = entry | timelineChildEntries(timelineEntries) %}
+  {% set relationshipCount = childEntries | length %}
+  {% set followUpText = "1 follow-up" if relationshipCount == 1 else (relationshipCount ~ " follow-ups") %}
+  {% set entryClasses = "timeline-entry" %}
+  {% if compact %}{% set entryClasses = entryClasses ~ " timeline-entry--compact" %}{% endif %}
+  {% if muted %}{% set entryClasses = entryClasses ~ " timeline-entry--muted" %}{% endif %}
+  <article class="{{ entryClasses }}" data-type="{{ timelineEntryType(entry) }}">
+    <div class="timeline-dot" aria-hidden="true"></div>
+    <div class="timeline-body-wrap">
+      <div class="timeline-topline">
+        <span class="timeline-handle">{{ me.profile.name }}</span>
+        <time class="timeline-timestamp" datetime="{{ entry.date | machineDate }}T{{ entry.data.time }}">{{ entry.date | readableDate }} · {{ entry.data.time }}</time>
+      </div>
+      {% if entry.data.title %}
+        <h2 class="timeline-title"><a href="{{ entry.url | url }}">{{ entry.data.title }}</a></h2>
+      {% endif %}
+      <div class="timeline-content">{{ entry.templateContent | safe }}</div>
+      {% if (showRelationships and (parentEntry or relationshipCount)) or (showTags and entryTags | length) %}
+        <div class="timeline-footer">
+          {% if showRelationships and (parentEntry or relationshipCount) %}
+            <div class="timeline-relationships">
+              {% if parentEntry %}
+                <a class="timeline-relationship" href="{{ entry.url | url }}">
+                  <span class="timeline-relationship__label">Continues from</span>
+                  <span>{{ parentEntry | timelineEntryLabel }}</span>
+                </a>
+              {% endif %}
+              {% if relationshipCount %}
+                <a class="timeline-relationship" href="{{ entry.url | url }}#timeline-children">
+                  <span>{{ followUpText }}</span>
+                </a>
+              {% endif %}
+            </div>
+          {% endif %}
+          {% if showTags and entryTags | length %}
+            <div class="timeline-tags">
+              {% for tag in entryTags %}<a href="/tags/{{ tag | slug }}/">#{{ tag }}</a>{% endfor %}
+            </div>
+          {% endif %}
+        </div>
+      {% endif %}
+    </div>
+  </article>
+{% endmacro %}

--- a/_includes/components/timeline-entry.njk
+++ b/_includes/components/timeline-entry.njk
@@ -152,14 +152,47 @@
     .timeline-thread__stack .timeline-entry:last-child {
       margin-bottom: 0;
     }
+
+    .timeline-thread__node + .timeline-thread__node {
+      margin-top: 1rem;
+    }
+
+    .timeline-thread__stack--nested {
+      margin-top: 0.75rem;
+      margin-left: 1.1rem;
+      padding-left: 0.85rem;
+    }
+
+    .timeline-thread__stack--nested::before {
+      background: rgba(0, 0, 0, 0.1);
+    }
+
+    .timeline-thread__continues {
+      margin: 0.45rem 0 0 2.25rem;
+      font-size: 0.78rem;
+      line-height: 1.4;
+      opacity: 0.55;
+      font-style: italic;
+    }
+
+    .timeline-thread__continues a {
+      color: inherit;
+      text-decoration: none;
+      border-bottom: 1px dotted currentColor;
+    }
+
+    .timeline-thread__continues a:hover,
+    .timeline-thread__continues a:focus {
+      opacity: 1;
+      text-decoration: underline;
+    }
   </style>
 {% endmacro %}
 
 {% macro renderTimelineEntry(entry, timelineEntries=[], compact=false, showRelationships=true, showTags=true, muted=false) %}
   {% set entryTags = (entry.data.tags | default([])) | filterTags %}
   {% set parentEntry = entry | timelineParentEntry(timelineEntries) %}
-  {% set childEntries = entry | timelineChildEntries(timelineEntries) %}
-  {% set relationshipCount = childEntries | length %}
+  {% set relationshipCount = entry | timelineDescendantCount(timelineEntries) %}
   {% set followUpText = "1 follow-up" if relationshipCount == 1 else (relationshipCount ~ " follow-ups") %}
   {% set entryClasses = "timeline-entry" %}
   {% if compact %}{% set entryClasses = entryClasses ~ " timeline-entry--compact" %}{% endif %}

--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/base.njk
 ---
+{% from "components/timeline-entry.njk" import renderTimelineEntry, renderTimelineStyles with context %}
 
 {% set siteThemeConfig = site.theme or {} %}
 {% set showThemeSelectors = siteThemeConfig.showSelectors if siteThemeConfig.showSelectors is defined else true %}
@@ -10,11 +11,20 @@ layout: layouts/base.njk
 {% set currentUrl = page.url or '/' %}
 {% set isPostPage = currentUrl.indexOf('/posts/') == 0 %}
 {% set isNotePage = currentUrl.indexOf('/notes/') == 0 %}
+{% set isTimelinePage = currentUrl.indexOf('/timeline/') == 0 %}
 {% set isPostDetailPage = isPostPage and currentUrl != '/posts/' %}
 {% set isNoteDetailPage = isNotePage and currentUrl != '/notes/' %}
+{% set isTimelineDetailPage = isTimelinePage and currentUrl != '/timeline/' %}
 {% set isArticlePage = isPostDetailPage or isNoteDetailPage %}
+{% set timelineEntries = collections.timeline | default([]) %}
+{% set currentTimelineEntry = page.url | timelineEntryByRef(timelineEntries) if isTimelineDetailPage else null %}
+{% set timelineAncestorChain = currentTimelineEntry | timelineAncestorEntries(timelineEntries) if currentTimelineEntry else [] %}
+{% set timelineChildEntries = currentTimelineEntry | timelineChildEntries(timelineEntries) if currentTimelineEntry else [] %}
 
 <div class="sans-serif">
+  {% if isTimelinePage %}
+    {{ renderTimelineStyles() }}
+  {% endif %}
   <style>
     /* Fade + Slide Keyframe Animations */
     @keyframes slideFadeIn {
@@ -206,6 +216,31 @@ layout: layouts/base.njk
       <heading-anchors>
         {{ content | safe }}
       </heading-anchors>
+      {% if isTimelineDetailPage and (timelineAncestorChain | length or timelineChildEntries | length) %}
+        <section class="timeline-thread">
+          {% if timelineAncestorChain | length %}
+            <div class="timeline-thread__branch timeline-thread__branch--parent">
+              <p class="timeline-thread__label">Earlier in thread</p>
+              <div class="timeline-thread__stack">
+                {% for ancestorEntry in timelineAncestorChain %}
+                  {{ renderTimelineEntry(ancestorEntry, timelineEntries, true, false, true, true) | safe }}
+                {% endfor %}
+              </div>
+            </div>
+          {% endif %}
+
+          {% if timelineChildEntries | length %}
+            <div id="timeline-children" class="timeline-thread__branch timeline-thread__branch--children">
+              <p class="timeline-thread__label">Follow-ups</p>
+              <div class="timeline-thread__stack">
+                {% for childEntry in timelineChildEntries %}
+                  {{ renderTimelineEntry(childEntry, timelineEntries, true, false, true, false) | safe }}
+                {% endfor %}
+              </div>
+            </div>
+          {% endif %}
+        </section>
+      {% endif %}
       {% if isArticlePage and giscusConfig.repo %}
         <script src="https://giscus.app/client.js"
                 data-repo="{{ giscusConfig.repo }}"

--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -19,7 +19,7 @@ layout: layouts/base.njk
 {% set timelineEntries = collections.timeline | default([]) %}
 {% set currentTimelineEntry = page.url | timelineEntryByRef(timelineEntries) if isTimelineDetailPage else null %}
 {% set timelineAncestorChain = currentTimelineEntry | timelineAncestorEntries(timelineEntries) if currentTimelineEntry else [] %}
-{% set timelineChildEntries = currentTimelineEntry | timelineChildEntries(timelineEntries) if currentTimelineEntry else [] %}
+{% set timelineFollowUpTree = currentTimelineEntry | timelineDescendantTree(timelineEntries, 2) if currentTimelineEntry else [] %}
 
 <div class="sans-serif">
   {% if isTimelinePage %}
@@ -216,7 +216,7 @@ layout: layouts/base.njk
       <heading-anchors>
         {{ content | safe }}
       </heading-anchors>
-      {% if isTimelineDetailPage and (timelineAncestorChain | length or timelineChildEntries | length) %}
+      {% if isTimelineDetailPage and (timelineAncestorChain | length or timelineFollowUpTree | length) %}
         <section class="timeline-thread">
           {% if timelineAncestorChain | length %}
             <div class="timeline-thread__branch timeline-thread__branch--parent">
@@ -229,12 +229,28 @@ layout: layouts/base.njk
             </div>
           {% endif %}
 
-          {% if timelineChildEntries | length %}
+          {% if timelineFollowUpTree | length %}
             <div id="timeline-children" class="timeline-thread__branch timeline-thread__branch--children">
               <p class="timeline-thread__label">Follow-ups</p>
               <div class="timeline-thread__stack">
-                {% for childEntry in timelineChildEntries %}
-                  {{ renderTimelineEntry(childEntry, timelineEntries, true, false, true, false) | safe }}
+                {% for childNode in timelineFollowUpTree %}
+                  <div class="timeline-thread__node">
+                    {{ renderTimelineEntry(childNode.entry, timelineEntries, true, false, true, false) | safe }}
+                    {% if childNode.children | length %}
+                      <div class="timeline-thread__stack timeline-thread__stack--nested">
+                        {% for grandchildNode in childNode.children %}
+                          <div class="timeline-thread__node">
+                            {{ renderTimelineEntry(grandchildNode.entry, timelineEntries, true, false, true, false) | safe }}
+                            {% if grandchildNode.continues %}
+                              <p class="timeline-thread__continues">
+                                <a href="{{ grandchildNode.entry.url | url }}#timeline-children">continues...</a>
+                              </p>
+                            {% endif %}
+                          </div>
+                        {% endfor %}
+                      </div>
+                    {% endif %}
+                  </div>
                 {% endfor %}
               </div>
             </div>

--- a/assets/images/subspace/timeline-feature/entry-with-nested-parents-details-view.png
+++ b/assets/images/subspace/timeline-feature/entry-with-nested-parents-details-view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee61136bb3e8efab83ab90d1e1d6ce1973e1f3f6f6e645df59a7d29551dbb055
+size 311653

--- a/assets/images/subspace/timeline-feature/entry-with-parent-and-child-details-view.png
+++ b/assets/images/subspace/timeline-feature/entry-with-parent-and-child-details-view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae7a73024f6414f8cc2a27f8f5e2bd4c7dc5a6ffa1c5bde76a79639aefb35c6e
+size 383412

--- a/assets/images/subspace/timeline-feature/grandparent-entry-details-view.png
+++ b/assets/images/subspace/timeline-feature/grandparent-entry-details-view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:582bc8ac2577035c0fec7abf3ef4e8f27a793b1022db5d2c9f8bfebf8b404276
+size 316700

--- a/assets/images/subspace/timeline-feature/timeline-view.png
+++ b/assets/images/subspace/timeline-feature/timeline-view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30b4b75550d2b1db38324bb845301ade4e0f2e95abbcc8178089f7b90c2e9950
+size 301926

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -194,6 +194,203 @@ const renderMarkdownCodeBlock = (code, language = '') => {
 const slugify = (value) =>
   encodeURIComponent(String(value).trim().toLowerCase().replace(/\s+/g, '-'));
 
+const toIsoDatePart = (value) => {
+  if (typeof value === 'string') {
+    return value.split('T')[0];
+  }
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value.toISOString().split('T')[0];
+  }
+  return '';
+};
+
+const getTimelineSortKey = (entry) => {
+  const date = toIsoDatePart(entry?.data?.date) || toIsoDatePart(entry?.date);
+  const time =
+    typeof entry?.data?.time === 'string' && entry.data.time.trim()
+      ? entry.data.time.trim()
+      : '00:00';
+  return `${date}T${time}`;
+};
+
+const normalizeTimelineRef = (value) => {
+  if (typeof value !== 'string') return '';
+
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+
+  let pathname = trimmed;
+  if (/^[a-z]+:\/\//i.test(trimmed)) {
+    try {
+      pathname = new URL(trimmed).pathname;
+    } catch {
+      return '';
+    }
+  }
+
+  if (!pathname.startsWith('/')) pathname = `/${pathname}`;
+  pathname = pathname.replace(/\/{2,}/g, '/');
+
+  return pathname.endsWith('/') ? pathname : `${pathname}/`;
+};
+
+const getTimelineEntryRef = (entryOrRef) => {
+  if (typeof entryOrRef === 'string') {
+    return normalizeTimelineRef(entryOrRef);
+  }
+  return normalizeTimelineRef(entryOrRef?.url || entryOrRef?.page?.url);
+};
+
+const getTimelineParentRef = (entry) =>
+  normalizeTimelineRef(entry?.data?.parent);
+
+const buildTimelineEntryMap = (entries = []) => {
+  const entryMap = new Map();
+
+  for (const entry of Array.isArray(entries) ? entries : []) {
+    const ref = getTimelineEntryRef(entry);
+    if (ref) entryMap.set(ref, entry);
+  }
+
+  return entryMap;
+};
+
+const getTimelineEntryByRef = (ref, entries = []) => {
+  const normalizedRef = getTimelineEntryRef(ref);
+  if (!normalizedRef) return null;
+  return buildTimelineEntryMap(entries).get(normalizedRef) || null;
+};
+
+const getTimelineChildEntries = (entryOrRef, entries = []) => {
+  const parentRef = getTimelineEntryRef(entryOrRef);
+  if (!parentRef) return [];
+
+  return (Array.isArray(entries) ? entries : [])
+    .filter((entry) => getTimelineParentRef(entry) === parentRef)
+    .sort((a, b) => getTimelineSortKey(a).localeCompare(getTimelineSortKey(b)));
+};
+
+const getTimelineAncestorEntries = (entryOrRef, entries = []) => {
+  const timelineEntries = Array.isArray(entries) ? entries : [];
+  const entryMap = buildTimelineEntryMap(timelineEntries);
+  const currentEntry =
+    typeof entryOrRef === 'string'
+      ? entryMap.get(getTimelineEntryRef(entryOrRef))
+      : entryOrRef;
+
+  if (!currentEntry) return [];
+
+  const ancestors = [];
+  let parentRef = getTimelineParentRef(currentEntry);
+
+  while (parentRef) {
+    const parentEntry = entryMap.get(parentRef);
+    if (!parentEntry) break;
+
+    ancestors.push(parentEntry);
+    parentRef = getTimelineParentRef(parentEntry);
+  }
+
+  return ancestors;
+};
+
+const getTimelineEntryLabel = (entry) => {
+  const title = entry?.data?.title;
+  if (typeof title === 'string' && title.trim()) return title.trim();
+
+  return (
+    getTimelineEntryRef(entry) ||
+    entry?.page?.fileSlug ||
+    entry?.fileSlug ||
+    'Untitled timeline entry'
+  );
+};
+
+const getTimelineEntrySource = (entry) =>
+  entry?.inputPath
+    ? path.relative(process.cwd(), entry.inputPath)
+    : getTimelineEntryRef(entry) || '(unknown timeline entry)';
+
+const validateTimelineEntryRelationships = (entries = []) => {
+  const timelineEntries = Array.isArray(entries) ? entries : [];
+  const entryMap = buildTimelineEntryMap(timelineEntries);
+  const failures = [];
+
+  for (const entry of timelineEntries) {
+    const rawParent = entry?.data?.parent;
+    if (rawParent === undefined || rawParent === null || rawParent === '') {
+      continue;
+    }
+
+    if (typeof rawParent !== 'string') {
+      failures.push(
+        `${getTimelineEntrySource(entry)}: parent must be a string URL path like "/timeline/example-entry/"`,
+      );
+      continue;
+    }
+
+    const entryRef = getTimelineEntryRef(entry);
+    const parentRef = normalizeTimelineRef(rawParent);
+
+    if (!parentRef) {
+      failures.push(
+        `${getTimelineEntrySource(entry)}: parent must be a URL path like "/timeline/example-entry/"`,
+      );
+      continue;
+    }
+
+    if (!parentRef.startsWith('/timeline/')) {
+      failures.push(
+        `${getTimelineEntrySource(entry)}: parent "${rawParent}" must point to a timeline entry URL under /timeline/`,
+      );
+      continue;
+    }
+
+    if (parentRef === entryRef) {
+      failures.push(
+        `${getTimelineEntrySource(entry)}: parent cannot point to the entry itself (${parentRef})`,
+      );
+      continue;
+    }
+
+    if (!entryMap.has(parentRef)) {
+      failures.push(
+        `${getTimelineEntrySource(entry)}: parent "${rawParent}" does not match any timeline entry URL`,
+      );
+    }
+  }
+
+  for (const entry of timelineEntries) {
+    const seenRefs = new Set();
+    let currentEntry = entry;
+
+    while (currentEntry) {
+      const currentRef = getTimelineEntryRef(currentEntry);
+      if (!currentRef) break;
+
+      if (seenRefs.has(currentRef)) {
+        failures.push(
+          `${getTimelineEntrySource(entry)}: parent chain creates a cycle at "${currentRef}"`,
+        );
+        break;
+      }
+
+      seenRefs.add(currentRef);
+
+      const parentRef = getTimelineParentRef(currentEntry);
+      if (!parentRef) break;
+
+      currentEntry = entryMap.get(parentRef);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `Invalid timeline parent relationships:\n  - ${failures.join('\n  - ')}`,
+    );
+  }
+};
+
 const loadSiteData = () => {
   try {
     const stats = fs.statSync(SITE_DATA_URL);
@@ -567,31 +764,33 @@ export default function (eleventyConfig) {
       .map((tag) => (typeof tag === 'string' ? tag : null))
       .filter((tag) => tag && !excludedTags.has(tag));
 
-  const toIsoDatePart = (value) => {
-    if (typeof value === 'string') {
-      return value.split('T')[0];
-    }
-    if (value instanceof Date && !Number.isNaN(value.getTime())) {
-      return value.toISOString().split('T')[0];
-    }
-    return '';
-  };
-
-  const getTimelineSortKey = (entry) => {
-    const date = toIsoDatePart(entry?.data?.date) || toIsoDatePart(entry?.date);
-    const time =
-      typeof entry?.data?.time === 'string' && entry.data.time.trim()
-        ? entry.data.time.trim()
-        : '00:00';
-    return `${date}T${time}`;
-  };
-
   eleventyConfig.on('eleventy.after', ({ dir }) => {
     emitFingerprintedAssets(dir?.output || '_site');
   });
 
   eleventyConfig.addDataExtension('yaml', (contents) => yaml.load(contents));
   eleventyConfig.addFilter('assetUrl', buildAssetUrl);
+  eleventyConfig.addFilter('timelineRef', (entryOrRef) =>
+    getTimelineEntryRef(entryOrRef),
+  );
+  eleventyConfig.addFilter('timelineEntryByRef', (ref, entries = []) =>
+    getTimelineEntryByRef(ref, entries),
+  );
+  eleventyConfig.addFilter('timelineParentEntry', (entry, entries = []) => {
+    const parentRef = getTimelineParentRef(entry);
+    if (!parentRef) return null;
+    return getTimelineEntryByRef(parentRef, entries);
+  });
+  eleventyConfig.addFilter('timelineChildEntries', (entryOrRef, entries = []) =>
+    getTimelineChildEntries(entryOrRef, entries),
+  );
+  eleventyConfig.addFilter(
+    'timelineAncestorEntries',
+    (entryOrRef, entries = []) => getTimelineAncestorEntries(entryOrRef, entries),
+  );
+  eleventyConfig.addFilter('timelineEntryLabel', (entry) =>
+    getTimelineEntryLabel(entry),
+  );
 
   eleventyConfig.addGlobalData(
     'environment',
@@ -676,11 +875,14 @@ export default function (eleventyConfig) {
     collectionApi.getFilteredByTag('notes'),
   );
 
-  eleventyConfig.addCollection('timeline', (collectionApi) =>
-    collectionApi.getFilteredByTag('timeline').sort((a, b) => {
+  eleventyConfig.addCollection('timeline', (collectionApi) => {
+    const timelineEntries = collectionApi.getFilteredByTag('timeline');
+    validateTimelineEntryRelationships(timelineEntries);
+
+    return timelineEntries.sort((a, b) => {
       return getTimelineSortKey(a).localeCompare(getTimelineSortKey(b));
-    }),
-  );
+    });
+  });
 
   eleventyConfig.addAsyncShortcode(
     'github',

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -833,11 +833,19 @@ export default function (eleventyConfig) {
     'posts',
     'notes',
     'timeline',
+    'testing',
   ]);
   const filterTagList = (tags = []) =>
     (Array.isArray(tags) ? tags : [tags])
       .map((tag) => (typeof tag === 'string' ? tag : null))
       .filter((tag) => tag && !excludedTags.has(tag));
+  const productionEnvironment = process.env.ELEVENTY_ENV === 'production';
+  const hasTag = (data, targetTag) =>
+    (Array.isArray(data?.tags) ? data.tags : [data?.tags]).some(
+      (tag) => typeof tag === 'string' && tag === targetTag,
+    );
+  const isTestingOnlyContent = (data) =>
+    productionEnvironment && hasTag(data, 'testing');
 
   eleventyConfig.on('eleventy.after', ({ dir }) => {
     emitFingerprintedAssets(dir?.output || '_site');
@@ -882,7 +890,7 @@ export default function (eleventyConfig) {
   );
   eleventyConfig.addGlobalData('eleventyComputed', {
     eleventyExcludeFromCollections(data) {
-      return data.draft && process.env.ELEVENTY_ENV === 'production';
+      return isTestingOnlyContent(data) || (data.draft && productionEnvironment);
     },
     title(data) {
       const prefix = '🚧 DRAFT - ';

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -261,13 +261,32 @@ const getTimelineEntryByRef = (ref, entries = []) => {
   return buildTimelineEntryMap(entries).get(normalizedRef) || null;
 };
 
+const buildTimelineChildMap = (entries = []) => {
+  const childMap = new Map();
+
+  for (const entry of Array.isArray(entries) ? entries : []) {
+    const parentRef = getTimelineParentRef(entry);
+    if (!parentRef) continue;
+
+    if (!childMap.has(parentRef)) childMap.set(parentRef, []);
+    childMap.get(parentRef).push(entry);
+  }
+
+  for (const childEntries of childMap.values()) {
+    childEntries.sort((a, b) =>
+      getTimelineSortKey(a).localeCompare(getTimelineSortKey(b)),
+    );
+  }
+
+  return childMap;
+};
+
 const getTimelineChildEntries = (entryOrRef, entries = []) => {
   const parentRef = getTimelineEntryRef(entryOrRef);
   if (!parentRef) return [];
 
-  return (Array.isArray(entries) ? entries : [])
-    .filter((entry) => getTimelineParentRef(entry) === parentRef)
-    .sort((a, b) => getTimelineSortKey(a).localeCompare(getTimelineSortKey(b)));
+  const childMap = buildTimelineChildMap(entries);
+  return childMap.get(parentRef) || [];
 };
 
 const getTimelineAncestorEntries = (entryOrRef, entries = []) => {
@@ -292,6 +311,62 @@ const getTimelineAncestorEntries = (entryOrRef, entries = []) => {
   }
 
   return ancestors;
+};
+
+const getTimelineDescendantCount = (entryOrRef, entries = []) => {
+  const rootRef = getTimelineEntryRef(entryOrRef);
+  if (!rootRef) return 0;
+
+  const childMap = buildTimelineChildMap(entries);
+  const countDescendants = (parentRef) => {
+    const childEntries = childMap.get(parentRef) || [];
+
+    return childEntries.reduce((count, childEntry) => {
+      const childRef = getTimelineEntryRef(childEntry);
+      return (
+        count +
+        1 +
+        (childRef ? countDescendants(childRef) : 0)
+      );
+    }, 0);
+  };
+
+  return countDescendants(rootRef);
+};
+
+const getTimelineDescendantTree = (entryOrRef, entries = [], maxDepth = 2) => {
+  const rootRef = getTimelineEntryRef(entryOrRef);
+  const normalizedMaxDepth = Number.isFinite(Number(maxDepth))
+    ? Math.max(0, Math.floor(Number(maxDepth)))
+    : 0;
+
+  if (!rootRef || normalizedMaxDepth < 1) return [];
+
+  const childMap = buildTimelineChildMap(entries);
+  const buildNodes = (parentRef, depthRemaining) => {
+    const childEntries = childMap.get(parentRef) || [];
+
+    return childEntries.map((childEntry) => {
+      const childRef = getTimelineEntryRef(childEntry);
+      const directChildren = childRef ? childMap.get(childRef) || [] : [];
+
+      if (depthRemaining <= 1) {
+        return {
+          entry: childEntry,
+          children: [],
+          continues: directChildren.length > 0,
+        };
+      }
+
+      return {
+        entry: childEntry,
+        children: childRef ? buildNodes(childRef, depthRemaining - 1) : [],
+        continues: false,
+      };
+    });
+  };
+
+  return buildNodes(rootRef, normalizedMaxDepth);
 };
 
 const getTimelineEntryLabel = (entry) => {
@@ -787,6 +862,15 @@ export default function (eleventyConfig) {
   eleventyConfig.addFilter(
     'timelineAncestorEntries',
     (entryOrRef, entries = []) => getTimelineAncestorEntries(entryOrRef, entries),
+  );
+  eleventyConfig.addFilter(
+    'timelineDescendantCount',
+    (entryOrRef, entries = []) => getTimelineDescendantCount(entryOrRef, entries),
+  );
+  eleventyConfig.addFilter(
+    'timelineDescendantTree',
+    (entryOrRef, entries = [], maxDepth = 2) =>
+      getTimelineDescendantTree(entryOrRef, entries, maxDepth),
   );
   eleventyConfig.addFilter('timelineEntryLabel', (entry) =>
     getTimelineEntryLabel(entry),

--- a/posts/subspace/threaded-timeline-entries.md
+++ b/posts/subspace/threaded-timeline-entries.md
@@ -1,0 +1,124 @@
+---
+title: I Built My Own Thread in Subspace Builder
+date: 2026-04-16
+tags:
+  - eleventy
+  - workflow
+excerpt: |
+  I wanted a thread-like place for public work notes that stayed fully mine. Threaded timeline entries let Subspace Builder capture progress in Markdown, in Git, and in whatever order the work actually happened.
+---
+
+One of the things I like most about building my own site is that I get to build my own thread too. Not a social feed owned by someone else, not a product shaped around somebody else's defaults, but a place where I can decide what counts as an update, how it connects to other updates, and what it looks like when it lands.
+
+I love this because it is fully under my own control and open to my own creative expression. I also do not have to be punctual in the usual sense. I can record things as I go, circle back later, add the missing middle, and generally write in a slightly non-linear, time-traveler way that feels much closer to how work actually happens.
+
+There is also a simpler reason I enjoy this feature so much: I really enjoy building Subspace Builder itself. Writing and creating in Markdown, backed by a Git repo, is still one of my favorite combinations of technology for making things. Timeline entries gave that workflow a lighter-weight publishing surface, and relational entries push it further by turning the feed from a flat log into a threaded record of work.
+
+
+<p class="tc f6 theme-midtone mt2">
+  This is what the feature looks like in practice: a timeline feed that can show both entry type and thread context at a glance.
+</p>
+<img alt="This is what the threaded timeline feature looks like: a color-coded timeline feed with continues-from and follow-up relationship cues between entries" src="/assets/images/subspace/timeline-feature/timeline-view.png"/>
+
+[[toc]]
+
+## Timeline Entries Add a Lightweight Publishing Layer
+
+One of the gaps in the site until now was the space between a full post and a private scratch note. Some updates deserve to be public, timestamped, and easy to revisit, but they do not need the weight of a long-form article.
+
+Timeline entries solve that. They live in `timeline/`, use familiar front matter, and get rendered into a dedicated `/timeline/` page as a stream of dated updates. Entry types are driven by tags rather than custom fields, which keeps the authoring model simple.
+
+```yaml
+---
+title: Shipped the timeline page
+date: "2026-04-14"
+time: "15:42"
+tags:
+  - timeline
+  - shipped
+---
+```
+
+That format matters for two reasons. First, it stays close to the rest of the content model, so writing a timeline entry feels like writing any other piece of Markdown in the project. Second, the explicit `time` field gives the collection stable within-day ordering, which is necessary once multiple updates can land on the same date.
+
+The tags also pull their weight visually. `shipped`, `published`, `wip`, `idea`, and `thinking` each get their own color, so the feed can communicate whether an item is a release, a concept, or a work-in-progress before you even read the body.
+
+## Relational Entries Turn the Timeline Into a Thread
+
+Flat timelines are useful, but they fall over a little once one piece of work evolves across multiple updates. You can see every entry, but the relationship between them still lives in the reader's head.
+
+That is what relational entries fix. A timeline item can now point to another one as its parent by using the parent entry's URL path in front matter.
+
+```yaml
+---
+title: Published relational timeline entry
+date: "2026-04-16"
+time: "10:30"
+parent: "/timeline/2026-04-14-shipped-timeline/"
+tags:
+  - timeline
+  - published
+---
+```
+
+This keeps the reference format dead simple: use the entry URL that already exists on the site. There is no extra ID system to maintain, and the relationship stays legible in the Markdown itself.
+
+The build now validates those relationships as well. A `parent` value has to point at a real `/timeline/.../` entry, it cannot point to itself, and it cannot create a cycle. That means broken relationships fail fast instead of quietly rendering bad UI.
+
+## The Feed Now Shows Context, Not Just Sequence
+
+The `/timeline/` page also changed to make those relationships visible at a glance. Instead of burying context inside each detail page, the feed now signals when an entry continues a previous one or has follow-ups of its own.
+
+Child entries show a `Continues from` chip, while parents show a follow-up count. That preserves the quick-scanning feel of the timeline while making it obvious that some entries belong to a larger chain.
+
+<img alt="Timeline page showing color-coded entries with relationship chips for continues-from links and follow-ups" src="/assets/images/subspace/timeline-feature/timeline-view.png" />
+<p class="tc f6 theme-midtone mt2">
+  Timeline entries now show relationship cues directly in the main feed.
+</p>
+
+That small cue is important. Readers do not need to guess whether an entry stands alone, and they do not need to open a detail page blindly to find out whether there is more context above or below it.
+
+## Entry Pages Behave More Like Threads Now
+
+The bigger UX shift happens on the entry pages themselves. Once you click into an item, the page now shows where that entry sits in a larger thread.
+
+Ancestor entries appear under `Earlier in thread`, and direct children appear under `Follow-ups`. The interface reuses the same timeline card pattern as the feed, so the relationship view feels like an extension of the timeline instead of a second unrelated layout.
+
+<img alt="Timeline entry detail page showing a parent entry above the current entry and follow-ups below" src="/assets/images/subspace/timeline-feature/entry-with-parent-and-child-details-view.png" />
+<p class="tc f6 theme-midtone mt2">
+  A timeline entry can now show both the context above it and the follow-ups below it.
+</p>
+
+That reuse matters more than it sounds. It means the same visual language carries through everywhere: timestamps, colored dots, title treatment, and tags all stay consistent whether you are skimming the main timeline or following a relationship chain in detail.
+
+The ancestor stack also works across more than one level now. If one entry continues another, which itself continues something earlier, the detail page can show that chain in order rather than only exposing a single parent hop.
+
+<img alt="Timeline entry detail page showing multiple ancestors stacked under Earlier in thread" src="/assets/images/subspace/timeline-feature/entry-with-nested-parents-details-view.png" />
+<p class="tc f6 theme-midtone mt2">
+  Nested parent chains can now render as a full thread instead of collapsing to a single parent hop.
+</p>
+
+<img alt="Grandparent timeline entry detail page showing the follow-ups thread beneath the main entry" src="/assets/images/subspace/timeline-feature/grandparent-entry-details-view.png" />
+<p class="tc f6 theme-midtone mt2">
+  Parent entries also show their follow-ups, which makes the thread navigable in both directions.
+</p>
+
+The result feels closer to a threaded conversation or a build log than a traditional archive page. That is the right direction for this feature.
+
+## Why This Matters for the Builder
+
+This is not only a nicer timeline page. It gives Subspace Builder a more useful publishing shape.
+
+Posts can still do the heavy lifting when an idea deserves structure, screenshots, explanation, and polish. Timeline entries now cover the smaller moments around that work: the initial idea, the work-in-progress checkpoint, the shipped update, and the later follow-up when the feature evolves again.
+
+Once entries can relate to each other, those smaller moments stop feeling disposable. They become a connected public trail of how a feature took shape.
+
+That makes the site more useful as both a reader experience and a maintainer tool. Readers can follow the story of a feature without losing context, and authors can publish incremental progress without forcing every update into the mold of a full article.
+
+## The Timeline Feels Like a Real Build Log Now
+
+The timeline started as a lighter publishing surface. With relational entries, it starts to become something more specific: a threadable build log for the site itself.
+
+That is the part I like most. It creates room for public thinking without flattening everything into either "tiny note" or "full release write-up." Some work deserves a chain of small updates, and now the site has a native way to represent that.
+
+With the screenshots in place, the shift from flat updates to threaded build-log entries is much easier to see.

--- a/posts/subspace/v1.13-1.20-roundup.md
+++ b/posts/subspace/v1.13-1.20-roundup.md
@@ -12,6 +12,8 @@ excerpt: |
 
 Subspace Builder has changed a lot since the last roundup. From `v1.13.0` through `v1.20.0`, the project picked up better editorial workflows, better code presentation, and better ways to navigate a growing site. Here is the short version of the releases that matter most.
 
+[[toc]]
+
 ## Drafts Stay Visible in Dev and Hidden in Production (v1.13.0)
 
 The first big quality-of-life improvement after `v1.12.0` was drafts support. Any post with `draft: true` in its front matter is now collected into a dedicated `/drafts/` page, which makes unfinished work easy to review while the local dev server is running.

--- a/src/timeline.njk
+++ b/src/timeline.njk
@@ -6,61 +6,10 @@ showPostHeader: false
 permalink: /timeline/
 ---
 
-<style>
-  .timeline-entry {
-    display: flex;
-    gap: 0.75rem;
-    margin-bottom: 0.75rem;
-    border-left: 3px solid var(--timeline-color, var(--accent));
-    padding: 0.875rem 1rem;
-    border-radius: 0 0.375rem 0.375rem 0;
-    background: rgba(128,128,128,0.04);
-  }
+{% from "components/timeline-entry.njk" import renderTimelineEntry with context %}
 
-  /* Color driven by tag */
-  .timeline-entry[data-type="shipped"]    { --timeline-color: #27ae60; }
-  .timeline-entry[data-type="published"]  { --timeline-color: #2980b9; }
-  .timeline-entry[data-type="wip"]        { --timeline-color: #8e44ad; }
-  .timeline-entry[data-type="idea"]       { --timeline-color: #f1c40f; }
-  .timeline-entry[data-type="thinking"]   { --timeline-color: #e67e22; }
-
-  .timeline-dot {
-    width: 0.5rem;
-    height: 0.5rem;
-    border-radius: 50%;
-    background: var(--timeline-color, var(--accent));
-    flex-shrink: 0;
-    margin-top: 0.45rem;
-  }
-
-  .timeline-body-wrap { flex: 1; min-width: 0; }
-
-  .timeline-topline {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    flex-wrap: wrap;
-    gap: 0.2rem 0.75rem;
-    margin-bottom: 0.25rem;
-  }
-  .timeline-handle { font-size: 0.8rem; opacity: 0.5; font-family: monospace; }
-  .timeline-timestamp { font-size: 0.75rem; opacity: 0.45; white-space: nowrap; }
-
-  .timeline-title { font-weight: 600; font-size: 0.9375rem; margin: 0 0 0.375rem; line-height: 1.3; }
-  .timeline-title a { text-decoration: none; }
-  .timeline-title a:hover { text-decoration: underline; }
-
-  .timeline-content { font-size: 0.875rem; line-height: 1.6; }
-  .timeline-content p { margin: 0 0 0.5em; }
-  .timeline-content p:last-child { margin-bottom: 0; }
-
-  .timeline-footer { margin-top: 0.6rem; }
-  .timeline-tags { display: flex; flex-wrap: wrap; gap: 0.2rem 0.4rem; }
-  .timeline-tags a { font-size: 0.7rem; opacity: 0.5; text-decoration: none; }
-  .timeline-tags a:hover { opacity: 1; text-decoration: underline; }
-</style>
-
-{% set logItems = collections.timeline | default([]) | reverse %}
+{% set timelineEntries = collections.timeline | default([]) %}
+{% set logItems = timelineEntries | reverse %}
 
 <section class="mw7">
   <h1 class="f3 f2-ns lh-title mt0 mb4">Timeline</h1>
@@ -68,34 +17,7 @@ permalink: /timeline/
   {% if logItems | length %}
     <div>
       {% for entry in logItems %}
-        {% set entryTags = (entry.data.tags | default([])) | filterTags %}
-        {% set entryType = "default" %}
-        {% if "shipped" in (entry.data.tags | default([])) %}{% set entryType = "shipped" %}
-        {% elif "published" in (entry.data.tags | default([])) %}{% set entryType = "published" %}
-        {% elif "wip" in (entry.data.tags | default([])) %}{% set entryType = "wip" %}
-        {% elif "idea" in (entry.data.tags | default([])) %}{% set entryType = "idea" %}
-        {% elif "thinking" in (entry.data.tags | default([])) %}{% set entryType = "thinking" %}
-        {% endif %}
-        <article class="timeline-entry" data-type="{{ entryType }}">
-          <div class="timeline-dot" aria-hidden="true"></div>
-          <div class="timeline-body-wrap">
-            <div class="timeline-topline">
-              <span class="timeline-handle">{{ me.profile.name }}</span>
-              <time class="timeline-timestamp" datetime="{{ entry.date | machineDate }}T{{ entry.data.time }}">{{ entry.date | readableDate }} · {{ entry.data.time }}</time>
-            </div>
-            {% if entry.data.title %}
-              <h2 class="timeline-title"><a href="{{ entry.url | url }}">{{ entry.data.title }}</a></h2>
-            {% endif %}
-            <div class="timeline-content">{{ entry.templateContent | safe }}</div>
-            {% if entryTags | length %}
-              <div class="timeline-footer">
-                <div class="timeline-tags">
-                  {% for tag in entryTags %}<a href="/tags/{{ tag | slug }}/">#{{ tag }}</a>{% endfor %}
-                </div>
-              </div>
-            {% endif %}
-          </div>
-        </article>
+        {{ renderTimelineEntry(entry, timelineEntries) | safe }}
       {% endfor %}
     </div>
   {% else %}

--- a/timeline/2026-04-16-published-relational-timeline-entry.md
+++ b/timeline/2026-04-16-published-relational-timeline-entry.md
@@ -1,5 +1,5 @@
 ---
-title: Published relational timeline entry
+title: Published the first threaded timeline update
 date: "2026-04-16"
 time: "10:30"
 parent: "/timeline/2026-04-14-shipped-timeline/"
@@ -8,6 +8,6 @@ tags:
   - published
 ---
 
-Published a follow-up timeline entry to test parent and child relationships between entries.
+Published the first follow-up entry in the new threaded timeline model.
 
-This one points back to the original timeline page launch entry so the relationship UI can be exercised on both pages.
+Timeline entries can now point back to earlier entries, which turns the feed into more of a build log than a flat list. This update continues from the original timeline launch and marks the point where parent and follow-up relationships became part of the feature.

--- a/timeline/2026-04-16-published-relational-timeline-entry.md
+++ b/timeline/2026-04-16-published-relational-timeline-entry.md
@@ -1,0 +1,13 @@
+---
+title: Published relational timeline entry
+date: "2026-04-16"
+time: "10:30"
+parent: "/timeline/2026-04-14-shipped-timeline/"
+tags:
+  - timeline
+  - published
+---
+
+Published a follow-up timeline entry to test parent and child relationships between entries.
+
+This one points back to the original timeline page launch entry so the relationship UI can be exercised on both pages.

--- a/timeline/2026-04-16-testing-deeper-relational-entry.md
+++ b/timeline/2026-04-16-testing-deeper-relational-entry.md
@@ -1,0 +1,14 @@
+---
+title: Deeper relational timeline entry for testing
+date: "2026-04-16"
+time: "10:55"
+parent: "/timeline/2026-04-16-testing-nested-relational-entry/"
+tags:
+  - timeline
+  - published
+  - testing
+---
+
+Fourth-level timeline entry for testing nested follow-up cutoffs.
+
+This entry exists for testing.

--- a/timeline/2026-04-16-testing-nested-relational-entry.md
+++ b/timeline/2026-04-16-testing-nested-relational-entry.md
@@ -1,0 +1,14 @@
+---
+title: Nested relational timeline entry for testing
+date: "2026-04-16"
+time: "10:45"
+parent: "/timeline/2026-04-16-published-relational-timeline-entry/"
+tags:
+  - timeline
+  - published
+  - testing
+---
+
+Third-level timeline entry for testing nested parent chains.
+
+This entry exists for testing.

--- a/timeline/2026-04-16-testing-sibling-relational-entry.md
+++ b/timeline/2026-04-16-testing-sibling-relational-entry.md
@@ -1,0 +1,14 @@
+---
+title: Sibling relational timeline entry for testing
+date: "2026-04-16"
+time: "10:50"
+parent: "/timeline/2026-04-16-published-relational-timeline-entry/"
+tags:
+  - timeline
+  - published
+  - testing
+---
+
+Sibling follow-up entry for testing branching on the same parent.
+
+This entry exists for testing.

--- a/timeline/timeline.11tydata.js
+++ b/timeline/timeline.11tydata.js
@@ -1,5 +1,15 @@
 export default {
   eleventyComputed: {
+    permalink: (data) => {
+      const tags = Array.isArray(data?.tags) ? data.tags : [data?.tags];
+      const isTestingEntry = tags.some(
+        (tag) => typeof tag === 'string' && tag === 'testing',
+      );
+
+      return isTestingEntry && process.env.ELEVENTY_ENV === 'production'
+        ? false
+        : undefined;
+    },
     ogImage: (data) => {
       const { ogImage, ogImages, page } = data;
       if (ogImage) return ogImage;


### PR DESCRIPTION
## What changed

This PR adds threaded relationships to timeline entries and rounds out the feature with improved thread UI, dev-only testing fixtures, and a write-up with screenshots.

It includes:
- parent/child relationships for timeline entries using entry URLs as refs
- relationship cues on `/timeline/` and threaded context on timeline detail pages
- recursive follow-up counts plus a two-level follow-up tree with a `continues...` link for deeper branches
- dev-only `testing` timeline entries that stay out of production builds
- a new post documenting the feature with screenshots

## Why

The timeline needed a lighter-weight way to capture work that evolves across multiple updates. Flat entries were fine for isolated notes, but they lost context once a feature had follow-ups.

This turns the timeline into something closer to a personal thread or build log while keeping the authoring flow in Markdown and Git.

## Impact

Readers can now move through related timeline updates with clearer context, and the feed signals when an entry continues an earlier one or has downstream follow-ups.

For development, there are dedicated `testing` entries to exercise nested relationships without leaking those fixtures into production output.

## Validation

- `npm run build`
- `ELEVENTY_ENV=development npx eleventy`
