### PR TITLE
feat: move template copy and timeline categories into data

### DIFF
--- a/CLAUDE.subspace.md
+++ b/CLAUDE.subspace.md
@@ -69,7 +69,8 @@ Timeline parent references use the entry URL path (`page.url`), including the tr
 Timeline feature documentation lives in `docs/feature-timeline.md`.
 If you change any timeline implementation detail, update `docs/feature-timeline.md` in the same change.
 Timeline archive indexes currently exist at `/timeline/weeks/` and `/timeline/months/`.
-Timeline page copy, relationship labels, archive labels, featured tags, and category metadata live in `_data/timeline.yaml`.
+Timeline page copy, relationship labels, and archive labels live in `_data/ui.yaml` under `pages.timeline`.
+Timeline featured tags and category metadata live in `_data/timeline.yaml`.
 
 ## Theme system
 
@@ -156,8 +157,8 @@ New gated nav items follow the same hardcoded pattern (matching how drafts are h
 | `_data/me.yaml` | author profile (`me.profile.name`, contacts, about text) |
 | `_data/themes.yaml` | theme definitions (id, label, classes, accent) |
 | `_data/series.yaml` | series metadata |
-| `_data/timeline.yaml` | timeline copy, labels, featured tags, and category metadata |
-| `_data/ui.yaml` | shared UI copy for templates and components |
+| `_data/timeline.yaml` | timeline featured tags and category metadata |
+| `_data/ui.yaml` | shared UI copy for templates and components, including `pages.timeline` |
 
 ## Skills
 

--- a/CLAUDE.subspace.md
+++ b/CLAUDE.subspace.md
@@ -23,7 +23,7 @@ src/              page templates (njk)
 _includes/
   layouts/        base.njk, home.njk + partials
   components/     reusable Nunjucks macros
-_data/            site.yaml, sidebarNav.yaml, themes.yaml, me.yaml, series.yaml, projects.yaml
+ _data/            site.yaml, sidebarNav.yaml, themes.yaml, me.yaml, series.yaml, projects.yaml, timeline.yaml, ui.yaml
 assets/css/       custom CSS (code-embeds, highlight, projects, codex-logbook)
 scripts/          OG image generation
 ```
@@ -60,11 +60,7 @@ time: "HH:MM"      # required; keep quoted, 24-hour HH:MM (e.g. "15:42")
 parent: "/timeline/2026-04-14-example-entry/" # optional; use the target entry's URL path
 tags:
   - timeline    # always present (set by timeline/timeline.json)
-  - shipped     # green  — something released
-  - published   # blue   — post or writing went out
-  - wip         # purple — work in progress
-  - idea        # yellow — rough concept worth tracking
-  - thinking    # amber  — idea, musing, planning
+  - shipped     # category tags and colors are defined in _data/timeline.yaml
   # any other tags are topic tags and get archive pages
 ```
 
@@ -73,6 +69,7 @@ Timeline parent references use the entry URL path (`page.url`), including the tr
 Timeline feature documentation lives in `docs/feature-timeline.md`.
 If you change any timeline implementation detail, update `docs/feature-timeline.md` in the same change.
 Timeline archive indexes currently exist at `/timeline/weeks/` and `/timeline/months/`.
+Timeline page copy, relationship labels, archive labels, featured tags, and category metadata live in `_data/timeline.yaml`.
 
 ## Theme system
 
@@ -159,6 +156,8 @@ New gated nav items follow the same hardcoded pattern (matching how drafts are h
 | `_data/me.yaml` | author profile (`me.profile.name`, contacts, about text) |
 | `_data/themes.yaml` | theme definitions (id, label, classes, accent) |
 | `_data/series.yaml` | series metadata |
+| `_data/timeline.yaml` | timeline copy, labels, featured tags, and category metadata |
+| `_data/ui.yaml` | shared UI copy for templates and components |
 
 ## Skills
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Markdown footnotes now work too, using standard `[^1]` references plus `[^1]: no
 
 ## Components & Enhancements
 
-- Use `{% from "components/post-list.njk" import renderPostList %}` inside a template to render a list of collection items with consistent styling.
+- Use `{% from "components/post-list.njk" import renderPostList with context %}` inside a template to render a list of collection items with consistent styling.
 - The `home.njk` layout wraps page content in a `<heading-anchors>` element to enable anchored headings and theme-aware typography.
 
 ## Deployment Tips

--- a/_data/timeline.yaml
+++ b/_data/timeline.yaml
@@ -1,89 +1,19 @@
 featuredTags:
   - timeline-page
 
-title: Timeline
-description: A personal timeline log, color-coded by entry type.
-
-labels:
-  root: Timeline
-  months: Months
-  weeks: Weeks
-
-featuredTopicsAriaLabel: Featured timeline topics
-
-entryCount:
-  singular: entry
-  plural: entries
-
-relationships:
-  continuesFrom: Continues from
-  followUpSingularTemplate: "{count} follow-up"
-  followUpPluralTemplate: "{count} follow-ups"
-
-thread:
-  earlierInThread: Earlier in thread
-  followUps: Follow-ups
-  continues: continues...
-
-emptyMessages:
-  mainHtml: No entries yet. Add a markdown file to <code>timeline/</code> to get started.
-  monthsIndex: No timeline months yet.
-  monthArchive: No timeline entries for this month.
-  weeksIndex: No timeline weeks yet.
-  weekArchive: No timeline entries for this week.
-  calendarWeekArchive: No timeline entries for this calendar week.
-  tagArchive: No timeline entries for this topic yet.
-
-monthsIndex:
-  title: Timeline Months
-  description: Timeline entries grouped into monthly archive pages.
-  intro: Monthly archive pages for the timeline.
-
-monthArchive:
-  titleTemplate: "Timeline: {label}"
-  descriptionTemplate: "Timeline entries from {label}."
-  countSuffix: in this month.
-  monthBandedWeeksHeading: Month-banded weeks in this month
-  calendarWeeksNoteHtml: Calendar weeks also live under <code>/timeline/weeks/</code>, using keys like <code>2026-W16</code>.
-
-weeksIndex:
-  title: Timeline Weeks
-  description: Timeline entries grouped into both month-banded and ISO calendar weeks.
-  intro: Month-banded weeks and ISO calendar week pages grouped by month. ISO weeks that cross a month boundary appear in both months.
-  monthBandedWeeksHeading: Month-banded weeks
-  calendarWeeksHeading: ISO calendar weeks
-
-weekArchive:
-  titleTemplate: "Timeline: {label}"
-  descriptionTemplate: "Timeline entries from {rangeLabel}."
-
-calendarWeekArchive:
-  titleTemplate: "Timeline: {label}"
-  descriptionTemplate: "Timeline entries from {rangeLabel}."
-
-tagArchive:
-  titleTemplate: "Timeline: {tag}"
-  descriptionTemplate: "Timeline entries tagged {tag}, in chronological context."
-  countSuffix: following this thread through the timeline.
-
 categories:
-  - id: shipped
-    tag: shipped
+  - tag: shipped
     label: Shipped
     color: "#27ae60"
-  - id: published
-    tag: published
+  - tag: published
     label: Published
     color: "#2980b9"
-  - id: wip
-    tag: wip
+  - tag: wip
     label: WIP
     color: "#8e44ad"
-  - id: idea
-    tag: idea
+  - tag: idea
     label: Idea
     color: "#f1c40f"
-  - id: thinking
-    tag: thinking
+  - tag: thinking
     label: Thinking
     color: "#e67e22"

--- a/_data/timeline.yaml
+++ b/_data/timeline.yaml
@@ -1,2 +1,89 @@
 featuredTags:
   - timeline-page
+
+title: Timeline
+description: A personal timeline log, color-coded by entry type.
+
+labels:
+  root: Timeline
+  months: Months
+  weeks: Weeks
+
+featuredTopicsAriaLabel: Featured timeline topics
+
+entryCount:
+  singular: entry
+  plural: entries
+
+relationships:
+  continuesFrom: Continues from
+  followUpSingularTemplate: "{count} follow-up"
+  followUpPluralTemplate: "{count} follow-ups"
+
+thread:
+  earlierInThread: Earlier in thread
+  followUps: Follow-ups
+  continues: continues...
+
+emptyMessages:
+  mainHtml: No entries yet. Add a markdown file to <code>timeline/</code> to get started.
+  monthsIndex: No timeline months yet.
+  monthArchive: No timeline entries for this month.
+  weeksIndex: No timeline weeks yet.
+  weekArchive: No timeline entries for this week.
+  calendarWeekArchive: No timeline entries for this calendar week.
+  tagArchive: No timeline entries for this topic yet.
+
+monthsIndex:
+  title: Timeline Months
+  description: Timeline entries grouped into monthly archive pages.
+  intro: Monthly archive pages for the timeline.
+
+monthArchive:
+  titleTemplate: "Timeline: {label}"
+  descriptionTemplate: "Timeline entries from {label}."
+  countSuffix: in this month.
+  monthBandedWeeksHeading: Month-banded weeks in this month
+  calendarWeeksNoteHtml: Calendar weeks also live under <code>/timeline/weeks/</code>, using keys like <code>2026-W16</code>.
+
+weeksIndex:
+  title: Timeline Weeks
+  description: Timeline entries grouped into both month-banded and ISO calendar weeks.
+  intro: Month-banded weeks and ISO calendar week pages grouped by month. ISO weeks that cross a month boundary appear in both months.
+  monthBandedWeeksHeading: Month-banded weeks
+  calendarWeeksHeading: ISO calendar weeks
+
+weekArchive:
+  titleTemplate: "Timeline: {label}"
+  descriptionTemplate: "Timeline entries from {rangeLabel}."
+
+calendarWeekArchive:
+  titleTemplate: "Timeline: {label}"
+  descriptionTemplate: "Timeline entries from {rangeLabel}."
+
+tagArchive:
+  titleTemplate: "Timeline: {tag}"
+  descriptionTemplate: "Timeline entries tagged {tag}, in chronological context."
+  countSuffix: following this thread through the timeline.
+
+categories:
+  - id: shipped
+    tag: shipped
+    label: Shipped
+    color: "#27ae60"
+  - id: published
+    tag: published
+    label: Published
+    color: "#2980b9"
+  - id: wip
+    tag: wip
+    label: WIP
+    color: "#8e44ad"
+  - id: idea
+    tag: idea
+    label: Idea
+    color: "#f1c40f"
+  - id: thinking
+    tag: thinking
+    label: Thinking
+    color: "#e67e22"

--- a/_data/ui.yaml
+++ b/_data/ui.yaml
@@ -1,0 +1,89 @@
+shared:
+  pagination:
+    previous: Previous
+    next: Next
+    page: Page
+    of: of
+    separator: "-"
+  counts:
+    entry:
+      singular: entry
+      plural: entries
+    post:
+      singular: post
+      plural: posts
+  projectCard:
+    imageAltSuffix: preview
+    links:
+      external: Link
+      timeline: Timeline
+      repository: GitHub
+  postList:
+    emptyDefault: No entries found.
+  series:
+    partOf: Part of a series
+    sectionLabel: Series
+    read: Read series
+    backToAll: Back to all series
+    sortOptions:
+      curated: Curated
+      reverse: Reverse
+      dateAsc: Oldest First
+      dateDesc: Newest First
+  theme:
+    previewAriaTemplate: "Preview {theme} theme"
+    modeLabelTemplate: "Theme mode: {mode}"
+    auto: Auto
+    custom: Custom
+
+pages:
+  home:
+    title: Home
+    heading: Latest Posts
+    emptyMessage: No posts published yet. Check back soon.
+  notes:
+    title: Notes
+    description: Shorter notes, references, and working ideas.
+    heading: Latest Notes
+    emptyMessage: No notes published yet. Add one in /notes/ to get started.
+  hiddenNotes:
+    title: Unlisted Notes
+    description: Notes that are public by URL but omitted from the main notes index.
+    heading: Unlisted Notes
+    emptyMessage: No unlisted notes found.
+  drafts:
+    title: Drafts
+    heading: Drafts
+    emptyMessage: No drafts found. Ship something new!
+  allTags:
+    title: All Tags
+    heading: All Tags
+    emptyMessage: No tags found.
+  tags:
+    taggedTitleTemplate: 'Tagged "{tag}"'
+    emptyMessage: No entries found for this tag.
+  about:
+    title: About
+    heading: About
+    siteHeadingFallback: About this site
+  projects:
+    title: Projects
+    description: Curated highlights from active builds and past experiments.
+    heading: Projects
+    intro: A look at current work plus past experiments that still spark ideas. Filter by technology to jump straight to the tools you care about.
+    filterHeading: Filter by technology
+    resetLabel: All projects
+    activeHeading: Active Projects
+    activeDescription: Currently maintained and frequently updated.
+    activeEmptyMessage: No active projects match that tag yet.
+    archivedHeading: Archive & Mentions
+    archivedDescription: Earlier builds and experiments that still influence newer work.
+    archivedEmptyMessage: No archived projects match that tag yet.
+    allEmptyMessage: No projects match that tag yet. Try resetting the filters.
+  series:
+    title: Series
+    description: Curated collections of related posts with editorial intros and flexible sorting.
+    heading: Series
+    intro: Curated reading paths through related posts. Each series starts in my recommended order, and the detail page can switch to reverse or date-based sorting.
+    emptyMessage: No series published yet.
+    detailEmptyMessage: This series does not have any published posts yet.

--- a/_data/ui.yaml
+++ b/_data/ui.yaml
@@ -87,3 +87,56 @@ pages:
     intro: Curated reading paths through related posts. Each series starts in my recommended order, and the detail page can switch to reverse or date-based sorting.
     emptyMessage: No series published yet.
     detailEmptyMessage: This series does not have any published posts yet.
+  timeline:
+    title: Timeline
+    description: A personal timeline log, color-coded by entry type.
+    labels:
+      root: Timeline
+      months: Months
+      weeks: Weeks
+    featuredTopicsAriaLabel: Featured timeline topics
+    entryCount:
+      singular: entry
+      plural: entries
+    relationships:
+      continuesFrom: Continues from
+      followUpSingularTemplate: "{count} follow-up"
+      followUpPluralTemplate: "{count} follow-ups"
+    thread:
+      earlierInThread: Earlier in thread
+      followUps: Follow-ups
+      continues: continues...
+    emptyMessages:
+      mainHtml: No entries yet. Add a markdown file to <code>timeline/</code> to get started.
+      monthsIndex: No timeline months yet.
+      monthArchive: No timeline entries for this month.
+      weeksIndex: No timeline weeks yet.
+      weekArchive: No timeline entries for this week.
+      calendarWeekArchive: No timeline entries for this calendar week.
+      tagArchive: No timeline entries for this topic yet.
+    monthsIndex:
+      title: Timeline Months
+      description: Timeline entries grouped into monthly archive pages.
+      intro: Monthly archive pages for the timeline.
+    monthArchive:
+      titleTemplate: "Timeline: {label}"
+      descriptionTemplate: "Timeline entries from {label}."
+      countSuffix: in this month.
+      monthBandedWeeksHeading: Month-banded weeks in this month
+      calendarWeeksNoteHtml: Calendar weeks also live under <code>/timeline/weeks/</code>, using keys like <code>2026-W16</code>.
+    weeksIndex:
+      title: Timeline Weeks
+      description: Timeline entries grouped into both month-banded and ISO calendar weeks.
+      intro: Month-banded weeks and ISO calendar week pages grouped by month. ISO weeks that cross a month boundary appear in both months.
+      monthBandedWeeksHeading: Month-banded weeks
+      calendarWeeksHeading: ISO calendar weeks
+    weekArchive:
+      titleTemplate: "Timeline: {label}"
+      descriptionTemplate: "Timeline entries from {rangeLabel}."
+    calendarWeekArchive:
+      titleTemplate: "Timeline: {label}"
+      descriptionTemplate: "Timeline entries from {rangeLabel}."
+    tagArchive:
+      titleTemplate: "Timeline: {tag}"
+      descriptionTemplate: "Timeline entries tagged {tag}, in chronological context."
+      countSuffix: following this thread through the timeline.

--- a/_data/ui.yaml
+++ b/_data/ui.yaml
@@ -4,7 +4,7 @@ shared:
     next: Next
     page: Page
     of: of
-    separator: "-"
+    separator: "·"
   counts:
     entry:
       singular: entry

--- a/_includes/components/post-list.njk
+++ b/_includes/components/post-list.njk
@@ -1,4 +1,4 @@
-{% macro renderPostList(items=[], emptyMessage='No entries found.', reverse=true) %}
+{% macro renderPostList(items=[], emptyMessage=ui.shared.postList.emptyDefault, reverse=true) %}
   {% set list = items or [] %}
   {% if list | length %}
     <div class="flex flex-column">

--- a/_includes/components/project-card.njk
+++ b/_includes/components/project-card.njk
@@ -13,7 +13,7 @@
       <figure class="project-card__media">
         <img
           src="{{ image.src }}"
-          alt="{{ image.alt or (project.name ~ ' preview') }}"
+          alt="{{ image.alt or (project.name ~ ' ' ~ ui.shared.projectCard.imageAltSuffix) }}"
           loading="lazy"
           decoding="async"
         >
@@ -34,17 +34,17 @@
         <div class="project-card__links mt0 mb3">
           {% if project.url %}
             <div class="project-card__link-item">
-              <a class="project-card__url link dim" href="{{ project.url }}">Link</a>
+              <a class="project-card__url link dim" href="{{ project.url }}">{{ ui.shared.projectCard.links.external }}</a>
             </div>
           {% endif %}
           {% if project.timeline %}
             <div class="project-card__link-item">
-              <a class="project-card__timeline link dim" href="{{ project.timeline }}">Timeline</a>
+              <a class="project-card__timeline link dim" href="{{ project.timeline }}">{{ ui.shared.projectCard.links.timeline }}</a>
             </div>
           {% endif %}
           {% if project.repo %}
             <div class="project-card__link-item">
-              <a class="project-card__repo link dim" href="{{ project.repo }}">GitHub</a>
+              <a class="project-card__repo link dim" href="{{ project.repo }}">{{ ui.shared.projectCard.links.repository }}</a>
             </div>
           {% endif %}
         </div>

--- a/_includes/components/timeline-entry.njk
+++ b/_includes/components/timeline-entry.njk
@@ -12,7 +12,7 @@
 
     /* Color driven by tag */
     {% for category in timeline.categories | default([]) %}
-      .timeline-entry[data-type="{{ category.id }}"] { --timeline-color: {{ category.color }}; }
+      .timeline-entry[data-type="{{ category.tag }}"] { --timeline-color: {{ category.color }}; }
     {% endfor %}
 
     .timeline-entry--compact {
@@ -180,7 +180,8 @@
   {% set entryTags = (entry.data.tags | default([])) | timelineTopicTags %}
   {% set parentEntry = entry | timelineParentEntry(timelineEntries) %}
   {% set relationshipCount = entry | timelineDescendantCount(timelineEntries) %}
-  {% set followUpText = (timeline.relationships.followUpSingularTemplate if relationshipCount == 1 else timeline.relationships.followUpPluralTemplate) | replace('{count}', relationshipCount) %}
+  {% set timelineUi = ui.pages.timeline %}
+  {% set followUpText = (timelineUi.relationships.followUpSingularTemplate if relationshipCount == 1 else timelineUi.relationships.followUpPluralTemplate) | replace('{count}', relationshipCount) %}
   {% set entryClasses = "timeline-entry" %}
   {% if compact %}{% set entryClasses = entryClasses ~ " timeline-entry--compact" %}{% endif %}
   {% if muted %}{% set entryClasses = entryClasses ~ " timeline-entry--muted" %}{% endif %}
@@ -201,7 +202,7 @@
             <div class="timeline-relationships">
               {% if parentEntry %}
                 <a class="timeline-relationship" href="{{ entry.url | url }}">
-                  <span class="timeline-relationship__label">{{ timeline.relationships.continuesFrom }}</span>
+                  <span class="timeline-relationship__label">{{ timelineUi.relationships.continuesFrom }}</span>
                   <span>{{ parentEntry | timelineEntryLabel }}</span>
                 </a>
               {% endif %}

--- a/_includes/components/timeline-entry.njk
+++ b/_includes/components/timeline-entry.njk
@@ -1,14 +1,3 @@
-{%- macro timelineEntryType(entry) -%}
-  {%- set entryType = "default" -%}
-  {%- if "shipped" in (entry.data.tags | default([])) -%}{%- set entryType = "shipped" -%}
-  {%- elif "published" in (entry.data.tags | default([])) -%}{%- set entryType = "published" -%}
-  {%- elif "wip" in (entry.data.tags | default([])) -%}{%- set entryType = "wip" -%}
-  {%- elif "idea" in (entry.data.tags | default([])) -%}{%- set entryType = "idea" -%}
-  {%- elif "thinking" in (entry.data.tags | default([])) -%}{%- set entryType = "thinking" -%}
-  {%- endif -%}
-  {{- entryType -}}
-{%- endmacro %}
-
 {% macro renderTimelineStyles() %}
   <style>
     .timeline-entry {
@@ -22,11 +11,9 @@
     }
 
     /* Color driven by tag */
-    .timeline-entry[data-type="shipped"]    { --timeline-color: #27ae60; }
-    .timeline-entry[data-type="published"]  { --timeline-color: #2980b9; }
-    .timeline-entry[data-type="wip"]        { --timeline-color: #8e44ad; }
-    .timeline-entry[data-type="idea"]       { --timeline-color: #f1c40f; }
-    .timeline-entry[data-type="thinking"]   { --timeline-color: #e67e22; }
+    {% for category in timeline.categories | default([]) %}
+      .timeline-entry[data-type="{{ category.id }}"] { --timeline-color: {{ category.color }}; }
+    {% endfor %}
 
     .timeline-entry--compact {
       padding: 0.75rem 0.875rem;
@@ -193,11 +180,11 @@
   {% set entryTags = (entry.data.tags | default([])) | timelineTopicTags %}
   {% set parentEntry = entry | timelineParentEntry(timelineEntries) %}
   {% set relationshipCount = entry | timelineDescendantCount(timelineEntries) %}
-  {% set followUpText = "1 follow-up" if relationshipCount == 1 else (relationshipCount ~ " follow-ups") %}
+  {% set followUpText = (timeline.relationships.followUpSingularTemplate if relationshipCount == 1 else timeline.relationships.followUpPluralTemplate) | replace('{count}', relationshipCount) %}
   {% set entryClasses = "timeline-entry" %}
   {% if compact %}{% set entryClasses = entryClasses ~ " timeline-entry--compact" %}{% endif %}
   {% if muted %}{% set entryClasses = entryClasses ~ " timeline-entry--muted" %}{% endif %}
-  <article class="{{ entryClasses }}" data-type="{{ timelineEntryType(entry) }}">
+  <article class="{{ entryClasses }}" data-type="{{ entry | timelineEntryType }}">
     <div class="timeline-dot" aria-hidden="true"></div>
     <div class="timeline-body-wrap">
       <div class="timeline-topline">
@@ -214,7 +201,7 @@
             <div class="timeline-relationships">
               {% if parentEntry %}
                 <a class="timeline-relationship" href="{{ entry.url | url }}">
-                  <span class="timeline-relationship__label">Continues from</span>
+                  <span class="timeline-relationship__label">{{ timeline.relationships.continuesFrom }}</span>
                   <span>{{ parentEntry | timelineEntryLabel }}</span>
                 </a>
               {% endif %}

--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -246,10 +246,10 @@ layout: layouts/base.njk
       {% if showThemeSelectors %}
       <div class="flex items-center flex-nowrap ml3-ns ml2" data-theme-selector>
         {% for theme in themes | reverse %}
-          <button type="button"
+                  <button type="button"
                   class="theme-preview-button w2 h2 bn pointer br2 mr2 mb2 pa0 ba b--transparent bg-transparent flex items-center justify-center"
                   data-theme-preview="{{ theme.id }}"
-                  aria-label="Preview {{ theme.label }} theme">
+                  aria-label="{{ ui.shared.theme.previewAriaTemplate | replace('{theme}', theme.label) }}">
             <span class="w-100 h-100 br2 flex items-center justify-center {{ theme.classes | join(' ') }}">
               Aa
             </span>
@@ -260,15 +260,15 @@ layout: layouts/base.njk
                 data-theme-mode-toggle
                 data-active
                 data-theme-mode="auto"
-                title="Theme mode: Auto"
-                aria-label="Theme mode: Auto">
+                title="{{ ui.shared.theme.modeLabelTemplate | replace('{mode}', ui.shared.theme.auto) }}"
+                aria-label="{{ ui.shared.theme.modeLabelTemplate | replace('{mode}', ui.shared.theme.auto) }}">
           <span class="theme-mode-surface w-100 h-100 br2 flex items-center justify-center">
             <span class="theme-mode-icon theme-mode-icon--auto" aria-hidden="true">
               <span class="theme-auto-icon"></span>
             </span>
             <span class="theme-mode-icon theme-mode-icon--light" aria-hidden="true">☀</span>
             <span class="theme-mode-icon theme-mode-icon--dark" aria-hidden="true">☾</span>
-            <span class="theme-mode-label">Auto</span>
+            <span class="theme-mode-label">{{ ui.shared.theme.auto }}</span>
           </span>
         </button>
       </div>
@@ -333,7 +333,7 @@ layout: layouts/base.njk
           {% set seriesLinks = postSeries | default([]) %}
           {% if isPostPage and seriesLinks | length %}
             <div class="pa3 ba b--black-10 br3 bg-white-20">
-              <p class="f6 ttu tracked theme-midtone mt0 mb2">Part of a series</p>
+              <p class="f6 ttu tracked theme-midtone mt0 mb2">{{ ui.shared.series.partOf }}</p>
               <ul class="list pl0 ma0">
                 {% for seriesItem in seriesLinks %}
                   <li{% if not loop.last %} class="mb2"{% endif %}>
@@ -341,7 +341,7 @@ layout: layouts/base.njk
                       {{ seriesItem.title }}
                     </a>
                     <span class="theme-midtone">
-                      ({{ seriesItem.position }} of {{ seriesItem.total }})
+                      ({{ seriesItem.position }} {{ ui.shared.pagination.of }} {{ seriesItem.total }})
                     </span>
                   </li>
                 {% endfor %}
@@ -357,7 +357,7 @@ layout: layouts/base.njk
         <section class="timeline-thread">
           {% if timelineEarlierThread | length %}
             <div class="timeline-thread__branch timeline-thread__branch--parent">
-              <p class="timeline-thread__label">Earlier in thread</p>
+              <p class="timeline-thread__label">{{ timeline.thread.earlierInThread }}</p>
               <div class="timeline-thread__stack">
                 {% for earlierEntry in timelineEarlierThread %}
                   {{ renderTimelineEntry(earlierEntry, timelineEntries, true, false, true, true) | safe }}
@@ -368,7 +368,7 @@ layout: layouts/base.njk
 
           {% if timelineFollowUpTree | length %}
             <div id="timeline-children" class="timeline-thread__branch timeline-thread__branch--children">
-              <p class="timeline-thread__label">Follow-ups</p>
+              <p class="timeline-thread__label">{{ timeline.thread.followUps }}</p>
               <div class="timeline-thread__stack">
                 {% for childNode in timelineFollowUpTree %}
                   <div class="timeline-thread__node">
@@ -380,7 +380,7 @@ layout: layouts/base.njk
                             {{ renderTimelineEntry(grandchildNode.entry, timelineEntries, true, false, true, false) | safe }}
                             {% if grandchildNode.continues %}
                               <p class="timeline-thread__continues">
-                                <a href="{{ grandchildNode.entry.url | url }}#timeline-children">continues...</a>
+                                <a href="{{ grandchildNode.entry.url | url }}#timeline-children">{{ timeline.thread.continues }}</a>
                               </p>
                             {% endif %}
                           </div>

--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -354,10 +354,11 @@ layout: layouts/base.njk
         {{ content | safe }}
       </heading-anchors>
       {% if isTimelineDetailPage and (timelineEarlierThread | length or timelineFollowUpTree | length) %}
+        {% set timelineUi = ui.pages.timeline %}
         <section class="timeline-thread">
           {% if timelineEarlierThread | length %}
             <div class="timeline-thread__branch timeline-thread__branch--parent">
-              <p class="timeline-thread__label">{{ timeline.thread.earlierInThread }}</p>
+              <p class="timeline-thread__label">{{ timelineUi.thread.earlierInThread }}</p>
               <div class="timeline-thread__stack">
                 {% for earlierEntry in timelineEarlierThread %}
                   {{ renderTimelineEntry(earlierEntry, timelineEntries, true, false, true, true) | safe }}
@@ -368,7 +369,7 @@ layout: layouts/base.njk
 
           {% if timelineFollowUpTree | length %}
             <div id="timeline-children" class="timeline-thread__branch timeline-thread__branch--children">
-              <p class="timeline-thread__label">{{ timeline.thread.followUps }}</p>
+              <p class="timeline-thread__label">{{ timelineUi.thread.followUps }}</p>
               <div class="timeline-thread__stack">
                 {% for childNode in timelineFollowUpTree %}
                   <div class="timeline-thread__node">
@@ -380,7 +381,7 @@ layout: layouts/base.njk
                             {{ renderTimelineEntry(grandchildNode.entry, timelineEntries, true, false, true, false) | safe }}
                             {% if grandchildNode.continues %}
                               <p class="timeline-thread__continues">
-                                <a href="{{ grandchildNode.entry.url | url }}#timeline-children">{{ timeline.thread.continues }}</a>
+                                <a href="{{ grandchildNode.entry.url | url }}#timeline-children">{{ timelineUi.thread.continues }}</a>
                               </p>
                             {% endif %}
                           </div>

--- a/_includes/layouts/partials/theme-preview-script.njk
+++ b/_includes/layouts/partials/theme-preview-script.njk
@@ -23,6 +23,9 @@
 		const storageKey = 'themePreference';
 		const previewResetDelay = {{ previewResetDelay }};
 		const previewHoverDelay = {{ siteThemeConfig.previewHoverDelay if siteThemeConfig.previewHoverDelay is defined else 120 }};
+		const themeModeLabelTemplate = {{ ui.shared.theme.modeLabelTemplate | dump | safe }};
+		const themeModeAutoLabel = {{ ui.shared.theme.auto | dump | safe }};
+		const themeModeCustomLabel = {{ ui.shared.theme.custom | dump | safe }};
 		const modePreferenceMap = {
 			auto: 'auto',
 			light: autoLightThemeId,
@@ -60,10 +63,15 @@
 		function updateModeToggle(preference) {
 			if (!modeToggleButton) return;
 			const mode = getModeForPreference(preference);
-			const label = mode ? mode.charAt(0).toUpperCase() + mode.slice(1) : 'Custom';
+			const label = mode === 'auto'
+				? themeModeAutoLabel
+				: mode
+					? mode.charAt(0).toUpperCase() + mode.slice(1)
+					: themeModeCustomLabel;
+			const modeLabel = themeModeLabelTemplate.replace('{mode}', label);
 			modeToggleButton.dataset.themeMode = mode || 'custom';
-			modeToggleButton.setAttribute('aria-label', `Theme mode: ${label}`);
-			modeToggleButton.setAttribute('title', `Theme mode: ${label}`);
+			modeToggleButton.setAttribute('aria-label', modeLabel);
+			modeToggleButton.setAttribute('title', modeLabel);
 			modeToggleButton.setAttribute('aria-pressed', String(Boolean(mode)));
 			modeToggleButton.classList.toggle('o-60', !mode);
 			if (mode) {

--- a/docs/feature-timeline.md
+++ b/docs/feature-timeline.md
@@ -24,10 +24,12 @@ Base data comes from:
 - `timeline/timeline.json`
 - `timeline/timeline.11tydata.js`
 - `_data/timeline.yaml`
+- `_data/ui.yaml`
 
 Timeline entries always carry the `timeline` tag through `timeline/timeline.json`.
-Timeline page copy, archive labels, relationship labels, featured tags, and
-category metadata are configured in `_data/timeline.yaml`.
+Timeline page copy, archive labels, relationship labels, and empty states live
+in `_data/ui.yaml` under `pages.timeline`.
+Timeline featured tags and category metadata live in `_data/timeline.yaml`.
 
 ## Timeline Entry Front Matter
 
@@ -53,20 +55,20 @@ Rules:
 
 ## Timeline Data Model
 
-`_data/timeline.yaml` is the source of truth for timeline presentation and
-category behavior.
+Timeline data is split between `_data/ui.yaml` and `_data/timeline.yaml`.
 
-It currently defines:
+`_data/ui.yaml` defines:
 - page and archive titles/descriptions
 - breadcrumb and section labels
 - empty-state copy
 - relationship and thread labels
+
+`_data/timeline.yaml` defines:
 - featured timeline tags
 - category metadata
 
 Category metadata is declared as an ordered `categories` array. Each item
 includes:
-- `id`
 - `tag`
 - `label`
 - `color`
@@ -171,8 +173,8 @@ Shared timeline entry rendering lives in:
 Shared week pill rendering lives in:
 - `_includes/components/timeline-week-pill.njk`
 
-`_includes/components/timeline-entry.njk` reads category ids and colors from
-`_data/timeline.yaml`.
+`_includes/components/timeline-entry.njk` reads category tags and colors from
+`_data/timeline.yaml`, and timeline copy from `_data/ui.yaml`.
 
 ## Social Preview Images
 

--- a/docs/feature-timeline.md
+++ b/docs/feature-timeline.md
@@ -23,8 +23,11 @@ Timeline entries live in `timeline/` as Markdown files.
 Base data comes from:
 - `timeline/timeline.json`
 - `timeline/timeline.11tydata.js`
+- `_data/timeline.yaml`
 
 Timeline entries always carry the `timeline` tag through `timeline/timeline.json`.
+Timeline page copy, archive labels, relationship labels, featured tags, and
+category metadata are configured in `_data/timeline.yaml`.
 
 ## Timeline Entry Front Matter
 
@@ -38,10 +41,8 @@ parent: "/timeline/example-entry/"
 tags:
   - timeline
   - shipped
-  - published
-  - wip
-  - idea
-  - thinking
+  # one optional category tag from _data/timeline.yaml
+  # any other tags are topic tags and get archive pages
 ```
 
 Rules:
@@ -49,6 +50,29 @@ Rules:
 - `time` must be a quoted string.
 - `parent` is optional, but when present it must be a valid `/timeline/.../` URL.
 - Timeline parent URLs must use trailing slashes.
+
+## Timeline Data Model
+
+`_data/timeline.yaml` is the source of truth for timeline presentation and
+category behavior.
+
+It currently defines:
+- page and archive titles/descriptions
+- breadcrumb and section labels
+- empty-state copy
+- relationship and thread labels
+- featured timeline tags
+- category metadata
+
+Category metadata is declared as an ordered `categories` array. Each item
+includes:
+- `id`
+- `tag`
+- `label`
+- `color`
+
+The order of `categories` defines precedence if an entry carries more than one
+category tag.
 
 ## Collection Model
 
@@ -71,6 +95,8 @@ Route pattern:
 - `/timeline/{tag-slug}/`
 
 Reserved or excluded tags are not promoted into topic archives. That includes content-type tags like `timeline` and timeline status tags like `shipped`, `published`, `wip`, `idea`, and `thinking`.
+Those reserved category tags are read from `_data/timeline.yaml` rather than
+being hardcoded in the templates.
 
 ### `collections.timelineMonths`
 
@@ -145,6 +171,9 @@ Shared timeline entry rendering lives in:
 Shared week pill rendering lives in:
 - `_includes/components/timeline-week-pill.njk`
 
+`_includes/components/timeline-entry.njk` reads category ids and colors from
+`_data/timeline.yaml`.
+
 ## Social Preview Images
 
 The Open Graph image pipeline generates cards for:
@@ -177,6 +206,7 @@ Current validation guarantees:
 - `parent` references must resolve to existing timeline entries
 - parent references may not create cycles
 - invalid topic archive slugs are rejected when they would collide with reserved timeline routes or entry URLs
+- category tags excluded from topic archives are taken from `_data/timeline.yaml`
 
 ## Navigation and Discoverability
 
@@ -195,6 +225,7 @@ Always update `docs/feature-timeline.md` when any timeline implementation change
 That includes changes to:
 - entry front matter requirements
 - tag handling
+- `_data/timeline.yaml` copy or category structure
 - collection shapes
 - route patterns
 - page templates

--- a/docs/plans/0002-multi-timeline-streams.md
+++ b/docs/plans/0002-multi-timeline-streams.md
@@ -1,0 +1,199 @@
+# 0002 - Multi-Stream Timeline System
+
+**Status:** Parked
+**Approach:** YAML-configured per-folder stream definitions
+
+---
+
+## Overview
+
+Generalize the current `timeline/` feature into a reusable stream system so the
+site can support multiple independent timeline-style sections such as
+`/timeline/`, `/logs/`, or future activity feeds.
+
+Each stream should be defined by YAML config in its own content folder. Eleventy
+should treat only explicitly configured folders as streams.
+
+---
+
+## Goals
+
+- Support multiple independent timeline-style content sections
+- Keep each stream self-contained in its own folder
+- Use YAML, not JSON, for stream configuration
+- Generate the same archive structure for each stream:
+  - root feed
+  - month index and month archive pages
+  - week index and week archive pages
+  - topic/tag archive pages
+- Allow per-stream labels, featured tags, category tags, and category colors
+- Scope parent/child validation, reserved routes, and topic archives per stream
+
+---
+
+## Non-Goals
+
+- Do not auto-detect arbitrary folders with Markdown content
+- Do not merge topic tags across streams
+- Do not implement cross-stream threading or shared archive pages
+- Do not change the current URL structure unless a stream explicitly opts into it
+
+---
+
+## Recommended Content Shape
+
+Example folders:
+
+```text
+timeline/
+  stream.yaml
+  timeline.json
+  2026-04-14-shipped-timeline.md
+
+logs/
+  stream.yaml
+  logs.json
+  2026-05-01-infra-log.md
+```
+
+The important part is the YAML stream config. The directory data file can remain
+small and only handle local Eleventy defaults like tags/layout if needed.
+
+I would make `stream.yaml` the source of truth for stream behavior.
+
+---
+
+## Recommended Stream Config
+
+Example `logs/stream.yaml`:
+
+```yaml
+id: logs
+title: Logs
+description: Build notes and operational updates.
+permalinkBase: /logs/
+entryTag: logs
+featuredTags:
+  - release
+  - infra
+
+labels:
+  root: Logs
+  months: Months
+  weeks: Weeks
+
+categories:
+  - id: shipped
+    tag: shipped
+    label: Shipped
+    color: "#27ae60"
+  - id: note
+    tag: note
+    label: Note
+    color: "#2980b9"
+```
+
+This keeps category detection, labels, and styling local to the stream.
+
+---
+
+## Discovery Rule
+
+Do not scan every top-level folder and guess.
+
+Only folders that contain an explicit `stream.yaml` should be treated as
+timeline-style streams. That keeps the build predictable and avoids accidental
+route generation.
+
+---
+
+## Routing Model
+
+For a stream with `permalinkBase: /logs/`, generate:
+
+- `/logs/`
+- `/logs/months/`
+- `/logs/months/{monthKey}/`
+- `/logs/weeks/`
+- `/logs/weeks/{monthKey}W{weekOfMonth}/`
+- `/logs/weeks/{isoYear}-W{isoWeek}/`
+- `/logs/{tag-slug}/`
+
+Each stream owns its own topic namespace. That means `/logs/shipped/` and
+`/timeline/shipped/` can both exist without conflict.
+
+---
+
+## Validation Rules
+
+Validation should be scoped per stream:
+
+- entries must carry the stream’s `entryTag`
+- parent refs must resolve only within the same stream
+- category tags reserved by a stream should be excluded from that stream’s topic archives
+- topic archive slugs should be checked only against that stream’s own reserved routes and entry URLs
+
+This avoids one stream’s category definitions leaking into another.
+
+---
+
+## Implementation Plan
+
+1. Extract the current timeline archive builders in `eleventy.config.js` into
+   generic stream-aware helpers.
+2. Add stream discovery from explicit `stream.yaml` files.
+3. Build a stream registry that Eleventy can use to generate per-stream
+   collections and archive pages.
+4. Refactor the current timeline templates into generic stream-aware templates
+   that receive a `stream` object.
+5. Migrate the existing `timeline/` feature to the new model first, keeping its
+   current URLs unchanged.
+6. After the migration is stable, add a second stream such as `logs/` as the
+   proof that the abstraction is real.
+
+---
+
+## Template Direction
+
+The current `src/timeline*.njk` family should eventually become generic stream
+templates. The rendering layer should read:
+
+- stream title/description
+- stream labels
+- stream category config
+- stream featured tags
+- stream archive copy
+
+from stream data instead of relying on timeline-specific literals.
+
+---
+
+## Open Decisions
+
+1. Exact filename for stream config:
+   - `stream.yaml` is my preferred option
+   - alternatives would be `_stream.yaml` or `{folder}.stream.yaml`
+
+2. Where shared default copy lives:
+   - global `_data` defaults with per-stream overrides
+   - or fully self-contained per-stream copy in each `stream.yaml`
+
+3. Whether a stream should be able to opt into nav automatically or whether nav
+   remains explicit in `_data/sidebarNav.yaml`
+
+4. Whether homepage or other pages should aggregate entries across all streams
+   later
+
+---
+
+## Recommendation
+
+When this gets implemented, start conservative:
+
+- explicit `stream.yaml`
+- per-stream topic archives
+- per-stream category config
+- no cross-stream aggregation
+- keep nav explicit
+
+That gives the flexibility you want without making the build behavior obscure.

--- a/docs/references/testing-static-generator-projects.md
+++ b/docs/references/testing-static-generator-projects.md
@@ -1,0 +1,137 @@
+# Testing Static Generator Projects
+
+Future implementation research note for adding tests to this Eleventy project.
+
+## Goal
+
+Test the generated contract of the site, not Eleventy internals. The most useful
+tests should catch broken rendered output, invalid data, and regressions in local
+generator logic.
+
+## Recommended Layers
+
+1. Build test
+
+   Keep `npm run build` as the first gate. It catches template syntax errors,
+   invalid data access, generator failures, and this repo's existing timeline
+   validation failures.
+
+2. Generated HTML contract tests
+
+   Build `_site`, parse important generated pages, and assert visible behavior:
+
+   - `/projects/` has project cards.
+   - project cards with `url` render non-empty `Link` anchors.
+   - project cards with `repo` render non-empty `GitHub` anchors.
+   - timeline pages render category color rules.
+   - timeline archive pages exist.
+   - pagination titles are stable.
+   - feature-flagged nav items appear or disappear correctly.
+   - no empty anchors like `<a href="..."></a>`.
+   - no unresolved template output like `{{ ... }}`.
+
+   Prefer a DOM parser such as `cheerio`, `linkedom`, or `jsdom` over broad raw
+   string matching.
+
+3. Data schema tests
+
+   Validate `_data/*.yaml` directly:
+
+   - `_data/timeline.yaml.categories[]` requires `tag`, `label`, and `color`.
+   - timeline category tags are unique.
+   - `featuredTags` is an array of strings.
+   - `ui.pages.timeline.*` required copy keys exist.
+   - project entries include required fields such as `name`, `summary`, and
+     `tech`.
+   - color values match the expected hex format.
+
+4. Unit tests for local helpers
+
+   Test local generator logic without booting Eleventy where possible:
+
+   - timeline sorting
+   - topic tag filtering
+   - category tag exclusion
+   - parent/child tree building
+   - archive key generation
+   - date/week/month grouping
+   - slug collision detection
+   - custom filters with real logic
+
+   If helpers remain embedded in `eleventy.config.js`, consider extracting them
+   into small modules before adding focused unit tests.
+
+5. Fixture builds
+
+   Use tiny fixture sites for complex generator behavior:
+
+   - one timeline entry
+   - parent/child timeline entries
+   - invalid parent reference
+   - tag/category collision
+   - multiple archive pages
+
+   Eleventy has a programmatic API that can write output with `.write()` or
+   inspect generated output with `.toJSON()`.
+
+6. Targeted snapshots
+
+   Use snapshots only when they are small and easy to review:
+
+   - normalized project card fragment
+   - normalized timeline entry fragment
+   - archive-generation JSON
+   - computed route list
+
+   Avoid snapshotting the whole `_site` or large full-page HTML output.
+
+7. Browser smoke tests
+
+   Use Playwright for a small number of integrated checks:
+
+   - homepage loads
+   - projects page shows link labels
+   - theme toggle works
+   - timeline page renders entries
+   - timeline detail pages show relationship sections
+   - key pages render at mobile and desktop widths
+
+8. Visual regression tests
+
+   Use sparingly for stable, high-value surfaces:
+
+   - project cards
+   - timeline entry layout
+   - homepage shell
+   - theme controls
+
+   Keep baselines deterministic and expect some OS/browser/font sensitivity.
+
+9. Accessibility and HTML quality
+
+   Add a small post-build pass over key pages:
+
+   - axe checks through Playwright
+   - generated HTML validation
+   - image `alt` checks
+   - heading-order checks
+   - link checks if not already covered by build validation
+
+## First Tests To Add Here
+
+1. Contract tests for `/projects/`, `/timeline/`, a timeline detail page, and
+   paginated home.
+2. Data schema tests for `_data/ui.yaml`, `_data/timeline.yaml`, and
+   `_data/projects.yaml`.
+3. Unit tests for timeline archive/category/relationship helpers.
+4. A Nunjucks macro import audit: any component macro that references global
+   data such as `ui`, `timeline`, or `me` must be imported `with context`.
+5. One Playwright smoke suite for homepage, projects, timeline, and theme mode.
+
+## References
+
+- Eleventy Programmatic API: https://www.11ty.dev/docs/programmatic/
+- Eleventy Configuration Events: https://www.11ty.dev/docs/events/
+- Playwright visual comparisons: https://playwright.dev/docs/test-snapshots
+- Playwright accessibility testing: https://playwright.dev/docs/accessibility-testing
+- Jest snapshot testing best practices: https://jestjs.io/docs/snapshot-testing

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -22,7 +22,12 @@ import excerpt from './lib/excerpt.js';
 const OG_FORCE_ENV = process.env.OG_FORCE === 'true';
 const ELEVENTY_FETCH_CACHE_DIR = path.resolve('.cache');
 const SITE_DATA_URL = new URL('./_data/site.yaml', import.meta.url);
+const TIMELINE_DATA_URL = new URL('./_data/timeline.yaml', import.meta.url);
 const siteDataCache = {
+  mtimeMs: null,
+  data: {},
+};
+const timelineDataCache = {
   mtimeMs: null,
   data: {},
 };
@@ -321,23 +326,40 @@ const formatCalendarWeekLabel = (isoYear, week) =>
   `Calendar Week ${String(week).padStart(2, '0')} · ${isoYear}`;
 
 const timelineReservedArchiveSlugs = new Set(['months', 'weeks']);
-const timelineTypeTags = new Set([
-  'shipped',
-  'published',
-  'wip',
-  'idea',
-  'thinking',
-]);
-const timelineArchiveExcludedTags = new Set([
-  'all',
-  'nav',
-  'post',
-  'posts',
-  'notes',
-  'timeline',
-  'testing',
-  ...timelineTypeTags,
-]);
+const getTimelineData = () => loadYamlData(TIMELINE_DATA_URL, timelineDataCache);
+
+const getTimelineCategories = () => {
+  const categories = getTimelineData()?.categories;
+  return Array.isArray(categories) ? categories : [];
+};
+
+const getTimelineTypeTags = () =>
+  new Set(
+    getTimelineCategories()
+      .map((category) => {
+        if (!category || typeof category !== 'object') return null;
+        if (typeof category.tag === 'string' && category.tag.trim()) {
+          return category.tag.trim();
+        }
+        if (typeof category.id === 'string' && category.id.trim()) {
+          return category.id.trim();
+        }
+        return null;
+      })
+      .filter(Boolean),
+  );
+
+const getTimelineArchiveExcludedTags = () =>
+  new Set([
+    'all',
+    'nav',
+    'post',
+    'posts',
+    'notes',
+    'timeline',
+    'testing',
+    ...getTimelineTypeTags(),
+  ]);
 
 const getTimelineSortKey = (entry) => {
   const date = toIsoDatePart(entry?.data?.date) || toIsoDatePart(entry?.date);
@@ -360,8 +382,32 @@ const getSortedTimelineEntries = (collectionApi) => {
 const getTimelineTopicTags = (tags = []) =>
   (Array.isArray(tags) ? tags : [tags])
     .map((tag) => (typeof tag === 'string' ? tag : null))
-    .filter((tag) => tag && !timelineArchiveExcludedTags.has(tag))
+    .filter((tag) => tag && !getTimelineArchiveExcludedTags().has(tag))
     .filter((tag, index, values) => values.indexOf(tag) === index);
+
+const getTimelineEntryType = (entry) => {
+  const tags = Array.isArray(entry?.data?.tags)
+    ? entry.data.tags
+    : [entry?.data?.tags].filter(Boolean);
+
+  for (const category of getTimelineCategories()) {
+    if (!category || typeof category !== 'object') continue;
+    const categoryId =
+      typeof category.id === 'string' && category.id.trim()
+        ? category.id.trim()
+        : null;
+    const categoryTag =
+      typeof category.tag === 'string' && category.tag.trim()
+        ? category.tag.trim()
+        : categoryId;
+
+    if (categoryId && categoryTag && tags.includes(categoryTag)) {
+      return categoryId;
+    }
+  }
+
+  return 'default';
+};
 
 const getTimelineEntrySlug = (entry) => {
   const url = typeof entry?.url === 'string' ? entry.url : '';
@@ -828,21 +874,23 @@ const validateTimelineEntryRelationships = (entries = []) => {
   }
 };
 
-const loadSiteData = () => {
+const loadYamlData = (fileUrl, cache) => {
   try {
-    const stats = fs.statSync(SITE_DATA_URL);
-    if (siteDataCache.mtimeMs === stats.mtimeMs) {
-      return siteDataCache.data;
+    const stats = fs.statSync(fileUrl);
+    if (cache.mtimeMs === stats.mtimeMs) {
+      return cache.data;
     }
-    const file = fs.readFileSync(SITE_DATA_URL, 'utf8');
+    const file = fs.readFileSync(fileUrl, 'utf8');
     const data = yaml.load(file);
-    siteDataCache.mtimeMs = stats.mtimeMs;
-    siteDataCache.data = data && typeof data === 'object' ? data : {};
-    return siteDataCache.data;
+    cache.mtimeMs = stats.mtimeMs;
+    cache.data = data && typeof data === 'object' ? data : {};
+    return cache.data;
   } catch {
     return {};
   }
 };
+
+const loadSiteData = () => loadYamlData(SITE_DATA_URL, siteDataCache);
 
 const assetFingerprintCache = new Map();
 const fingerprintedAssets = new Map();
@@ -1491,6 +1539,9 @@ export default function (eleventyConfig) {
   eleventyConfig.addFilter('filterTags', filterTagList);
   eleventyConfig.addFilter('timelineTopicTags', (tags = []) =>
     getTimelineTopicTags(filterTagList(tags)),
+  );
+  eleventyConfig.addFilter('timelineEntryType', (entry) =>
+    getTimelineEntryType(entry),
   );
 
   eleventyConfig.addFilter('slug', (value) => {

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -341,9 +341,6 @@ const getTimelineTypeTags = () =>
         if (typeof category.tag === 'string' && category.tag.trim()) {
           return category.tag.trim();
         }
-        if (typeof category.id === 'string' && category.id.trim()) {
-          return category.id.trim();
-        }
         return null;
       })
       .filter(Boolean),
@@ -392,17 +389,13 @@ const getTimelineEntryType = (entry) => {
 
   for (const category of getTimelineCategories()) {
     if (!category || typeof category !== 'object') continue;
-    const categoryId =
-      typeof category.id === 'string' && category.id.trim()
-        ? category.id.trim()
-        : null;
     const categoryTag =
       typeof category.tag === 'string' && category.tag.trim()
         ? category.tag.trim()
-        : categoryId;
+        : null;
 
-    if (categoryId && categoryTag && tags.includes(categoryTag)) {
-      return categoryId;
+    if (categoryTag && tags.includes(categoryTag)) {
+      return categoryTag;
     }
   }
 

--- a/src/about.njk
+++ b/src/about.njk
@@ -1,8 +1,9 @@
 ---
 layout: layouts/home.njk
-title: About
 showPostHeader: false
 permalink: /about/
+eleventyComputed:
+  title: "{{ ui.pages.about.title }}"
 ---
 
 {% set profile = me.profile or {} %}
@@ -14,7 +15,7 @@ permalink: /about/
 <section class="mw8 center">
   <div class="flex flex-column flex-row-l">
     <div class="w-100 w-two-thirds-l pr0 pr5-l">
-      <h1 class="f3 f2-ns lh-title mt0 mb3">About</h1>
+      <h1 class="f3 f2-ns lh-title mt0 mb3">{{ ui.pages.about.heading }}</h1>
       {% for paragraph in introCopy %}
         <p class="f5 lh-copy mt0{% if not loop.first %} mt3{% endif %}">
           {{ paragraph | safe }}
@@ -60,7 +61,7 @@ permalink: /about/
 
 <section class="mw7 center mt5">
   <h2 class="f3 f2-ns lh-title mt0">
-    {{ aboutSite.heading | default('About this site') }}
+    {{ aboutSite.heading | default(ui.pages.about.siteHeadingFallback) }}
   </h2>
   {% for paragraph in aboutSiteParagraphs %}
     <p class="f5 lh-copy mt3">

--- a/src/all-tags.njk
+++ b/src/all-tags.njk
@@ -1,19 +1,20 @@
 ---
 layout: layouts/home.njk
-title: All Tags
 eleventyNavigation:
   key: tags
 showPostHeader: false
 permalink: /tags/
+eleventyComputed:
+  title: "{{ ui.pages.allTags.title }}"
 ---
 
 <section class="mw7 center">
-  <h1 class="f3 f2-ns lh-title mt0 mb4">All Tags</h1>
+  <h1 class="f3 f2-ns lh-title mt0 mb4">{{ ui.pages.allTags.heading }}</h1>
   {% if collections.tagGroups | length %}
     {% for group in collections.tagGroups %}
       <div class="mb4">
         <h2 class="f6 ttu tracked theme-midtone mt0 mb2">
-          {{ group.count }} post{% if group.count != 1 %}s{% endif %}
+          {{ group.count }} {{ ui.shared.counts.post.singular if group.count == 1 else ui.shared.counts.post.plural }}
         </h2>
         <ul class="list pl0 ma0 flex flex-wrap">
           {% for tag in group.tags %}
@@ -28,6 +29,6 @@ permalink: /tags/
       </div>
     {% endfor %}
   {% else %}
-    <p class="theme-midtone">No tags found.</p>
+    <p class="theme-midtone">{{ ui.pages.allTags.emptyMessage }}</p>
   {% endif %}
 </section>

--- a/src/drafts.njk
+++ b/src/drafts.njk
@@ -5,7 +5,7 @@ eleventyComputed:
   title: "{{ ui.pages.drafts.title }}"
 ---
 
-{% from "components/post-list.njk" import renderPostList %}
+{% from "components/post-list.njk" import renderPostList with context %}
 
 <section class="mw7 center">
   <h1 class="f3 f2-ns lh-title mt0 mb0">{{ ui.pages.drafts.heading }}</h1>

--- a/src/drafts.njk
+++ b/src/drafts.njk
@@ -1,12 +1,13 @@
 ---
 layout: layouts/home.njk
-title: Drafts
 permalink: /drafts/
+eleventyComputed:
+  title: "{{ ui.pages.drafts.title }}"
 ---
 
 {% from "components/post-list.njk" import renderPostList %}
 
 <section class="mw7 center">
-  <h1 class="f3 f2-ns lh-title mt0 mb0">Drafts</h1>
-  {{ renderPostList(collections.drafts, "No drafts found. Ship something new!") | safe }}
+  <h1 class="f3 f2-ns lh-title mt0 mb0">{{ ui.pages.drafts.heading }}</h1>
+  {{ renderPostList(collections.drafts, ui.pages.drafts.emptyMessage) | safe }}
 </section>

--- a/src/hidden-notes.njk
+++ b/src/hidden-notes.njk
@@ -7,7 +7,7 @@ eleventyComputed:
   description: "{{ ui.pages.hiddenNotes.description }}"
 ---
 
-{% from "components/post-list.njk" import renderPostList %}
+{% from "components/post-list.njk" import renderPostList with context %}
 
 <section class="mw7 center">
   <h1 class="f3 f2-ns lh-title mt0 mb0">{{ ui.pages.hiddenNotes.heading }}</h1>

--- a/src/hidden-notes.njk
+++ b/src/hidden-notes.njk
@@ -1,14 +1,15 @@
 ---
 layout: layouts/home.njk
-title: Unlisted Notes
-description: Notes that are public by URL but omitted from the main notes index.
 permalink: /notes/hidden/
 comments: false
+eleventyComputed:
+  title: "{{ ui.pages.hiddenNotes.title }}"
+  description: "{{ ui.pages.hiddenNotes.description }}"
 ---
 
 {% from "components/post-list.njk" import renderPostList %}
 
 <section class="mw7 center">
-  <h1 class="f3 f2-ns lh-title mt0 mb0">Unlisted Notes</h1>
-  {{ renderPostList(collections.hiddenNotes, "No unlisted notes found.") | safe }}
+  <h1 class="f3 f2-ns lh-title mt0 mb0">{{ ui.pages.hiddenNotes.heading }}</h1>
+  {{ renderPostList(collections.hiddenNotes, ui.pages.hiddenNotes.emptyMessage) | safe }}
 </section>

--- a/src/index.njk
+++ b/src/index.njk
@@ -1,31 +1,30 @@
 ---
 layout: layouts/home.njk
-title: Home
 pagination:
   data: collections.posts
   size: 10 # posts per page
   reverse: true
 permalink: "{% if pagination.pageNumber == 0 %}/{% else %}/page/{{ pagination.pageNumber + 1 }}/{% endif %}"
 eleventyComputed:
-  title: "{% if pagination.pageNumber == 0 %}Home{% else %}Home · Page {{ pagination.pageNumber + 1 }}{% endif %}"
+  title: "{% if pagination.pageNumber == 0 %}{{ ui.pages.home.title }}{% else %}{{ ui.pages.home.title }} {{ ui.shared.pagination.separator }} {{ ui.shared.pagination.page }} {{ pagination.pageNumber + 1 }}{% endif %}"
 ---
 
 {% from "components/post-list.njk" import renderPostList %}
 
 <section class="mw7 center">
-  <h1 class="f3 f2-ns lh-title mt0 mb0">Latest Posts</h1>
-  {{ renderPostList(pagination.items, "No posts published yet. Check back soon.", false) | safe }}
+  <h1 class="f3 f2-ns lh-title mt0 mb0">{{ ui.pages.home.heading }}</h1>
+  {{ renderPostList(pagination.items, ui.pages.home.emptyMessage, false) | safe }}
   {% if pagination.pages | length > 1 %}
     <nav class="flex justify-between items-center f6 theme-midtone mt4">
       <div>
         {% if pagination.href.previous %}
-          <a class="link dim theme-text" href="{{ pagination.href.previous }}">Previous</a>
+          <a class="link dim theme-text" href="{{ pagination.href.previous }}">{{ ui.shared.pagination.previous }}</a>
         {% endif %}
       </div>
-      <div>Page {{ pagination.pageNumber + 1 }} of {{ pagination.pages | length }}</div>
+      <div>{{ ui.shared.pagination.page }} {{ pagination.pageNumber + 1 }} {{ ui.shared.pagination.of }} {{ pagination.pages | length }}</div>
       <div>
         {% if pagination.href.next %}
-          <a class="link dim theme-text" href="{{ pagination.href.next }}">Next</a>
+          <a class="link dim theme-text" href="{{ pagination.href.next }}">{{ ui.shared.pagination.next }}</a>
         {% endif %}
       </div>
     </nav>

--- a/src/index.njk
+++ b/src/index.njk
@@ -9,7 +9,7 @@ eleventyComputed:
   title: "{% if pagination.pageNumber == 0 %}{{ ui.pages.home.title }}{% else %}{{ ui.pages.home.title }} {{ ui.shared.pagination.separator }} {{ ui.shared.pagination.page }} {{ pagination.pageNumber + 1 }}{% endif %}"
 ---
 
-{% from "components/post-list.njk" import renderPostList %}
+{% from "components/post-list.njk" import renderPostList with context %}
 
 <section class="mw7 center">
   <h1 class="f3 f2-ns lh-title mt0 mb0">{{ ui.pages.home.heading }}</h1>

--- a/src/notes.njk
+++ b/src/notes.njk
@@ -6,7 +6,7 @@ eleventyComputed:
   description: "{{ ui.pages.notes.description }}"
 ---
 
-{% from "components/post-list.njk" import renderPostList %}
+{% from "components/post-list.njk" import renderPostList with context %}
 
 <section class="mw7 center">
   <h1 class="f3 f2-ns lh-title mt0 mb0">{{ ui.pages.notes.heading }}</h1>

--- a/src/notes.njk
+++ b/src/notes.njk
@@ -1,13 +1,14 @@
 ---
 layout: layouts/home.njk
-title: Notes
-description: Shorter notes, references, and working ideas.
 permalink: /notes/
+eleventyComputed:
+  title: "{{ ui.pages.notes.title }}"
+  description: "{{ ui.pages.notes.description }}"
 ---
 
 {% from "components/post-list.njk" import renderPostList %}
 
 <section class="mw7 center">
-  <h1 class="f3 f2-ns lh-title mt0 mb0">Latest Notes</h1>
-  {{ renderPostList(collections.notes, "No notes published yet. Add one in /notes/ to get started.") | safe }}
+  <h1 class="f3 f2-ns lh-title mt0 mb0">{{ ui.pages.notes.heading }}</h1>
+  {{ renderPostList(collections.notes, ui.pages.notes.emptyMessage) | safe }}
 </section>

--- a/src/projects.njk
+++ b/src/projects.njk
@@ -11,7 +11,7 @@ eleventyComputed:
   description: "{{ ui.pages.projects.description }}"
 ---
 
-{% from "components/project-card.njk" import renderProjectCard %}
+{% from "components/project-card.njk" import renderProjectCard with context %}
 {% from "components/tag-chip.njk" import renderTagChip %}
 
 {% set hasActive = activeProjects | length %}

--- a/src/projects.njk
+++ b/src/projects.njk
@@ -1,13 +1,14 @@
 ---
 layout: layouts/home.njk
-title: Projects
-description: Curated highlights from active builds and past experiments.
 showPostHeader: false
 permalink: /projects/
 stylesheets:
   - /assets/css/projects.css
 scripts:
   - /assets/js/projects-filter.js
+eleventyComputed:
+  title: "{{ ui.pages.projects.title }}"
+  description: "{{ ui.pages.projects.description }}"
 ---
 
 {% from "components/project-card.njk" import renderProjectCard %}
@@ -19,24 +20,23 @@ scripts:
 
 <section class="projects-shell mw8 center" data-projects>
   <header class="projects-header">
-    <h1 class="f3 f2-ns lh-title mt0 mb3">Projects</h1>
+    <h1 class="f3 f2-ns lh-title mt0 mb3">{{ ui.pages.projects.heading }}</h1>
     <p class="f5 f4-ns lh-copy mt0 mb4 theme-midtone">
-      A look at current work plus past experiments that still spark ideas.
-      Filter by technology to jump straight to the tools you care about.
+      {{ ui.pages.projects.intro }}
     </p>
   </header>
 
   {% if hasTags %}
     <section class="projects-filter ba b--black-10 br3 pa3 pa4-ns mb5" data-project-filter-bar>
       <div class="flex items-center justify-between flex-wrap mb3">
-        <h2 class="f6 ttu tracked mv0 theme-midtone">Filter by technology</h2>
+        <h2 class="f6 ttu tracked mv0 theme-midtone">{{ ui.pages.projects.filterHeading }}</h2>
         <button
           type="button"
           class="project-tag project-tag--filter mr2 mb2"
           data-project-filter-reset
           aria-pressed="true"
         >
-          <span class="project-tag__label">All projects</span>
+          <span class="project-tag__label">{{ ui.pages.projects.resetLabel }}</span>
         </button>
       </div>
       <div class="flex flex-wrap">
@@ -55,9 +55,9 @@ scripts:
     {% if hasActive %}
       <section class="projects-section mb5" data-project-section="active">
         <header class="projects-section__header mb3">
-          <h2 class="f4 f3-ns lh-title mv0">Active Projects</h2>
+          <h2 class="f4 f3-ns lh-title mv0">{{ ui.pages.projects.activeHeading }}</h2>
           <p class="f6 f5-ns lh-copy mt2 mb0 theme-midtone">
-            Currently maintained and frequently updated.
+            {{ ui.pages.projects.activeDescription }}
           </p>
         </header>
         <div class="projects-grid" data-project-list>
@@ -66,7 +66,7 @@ scripts:
           {% endfor %}
         </div>
         <p class="projects-section__empty theme-midtone dn" data-project-section-empty>
-          No active projects match that tag yet.
+          {{ ui.pages.projects.activeEmptyMessage }}
         </p>
       </section>
     {% endif %}
@@ -74,9 +74,9 @@ scripts:
     {% if hasArchived %}
       <section class="projects-section mb5" data-project-section="archived">
         <header class="projects-section__header mb3">
-          <h2 class="f4 f3-ns lh-title mv0">Archive &amp; Mentions</h2>
+          <h2 class="f4 f3-ns lh-title mv0">{{ ui.pages.projects.archivedHeading }}</h2>
           <p class="f6 f5-ns lh-copy mt2 mb0 theme-midtone">
-            Earlier builds and experiments that still influence newer work.
+            {{ ui.pages.projects.archivedDescription }}
           </p>
         </header>
         <div class="projects-grid" data-project-list>
@@ -85,13 +85,13 @@ scripts:
           {% endfor %}
         </div>
         <p class="projects-section__empty theme-midtone dn" data-project-section-empty>
-          No archived projects match that tag yet.
+          {{ ui.pages.projects.archivedEmptyMessage }}
         </p>
       </section>
     {% endif %}
   </div>
 
   <p class="projects-empty theme-midtone dn" data-projects-empty>
-    No projects match that tag yet. Try resetting the filters.
+    {{ ui.pages.projects.allEmptyMessage }}
   </p>
 </section>

--- a/src/series/index.njk
+++ b/src/series/index.njk
@@ -1,20 +1,19 @@
 ---
 layout: layouts/home.njk
-title: Series
-description: Curated collections of related posts with editorial intros and flexible sorting.
 showPostHeader: false
 permalink: /series/
+eleventyComputed:
+  title: "{{ ui.pages.series.title }}"
+  description: "{{ ui.pages.series.description }}"
 ---
 
 {% set seriesList = series | default([]) %}
 
 <section class="mw7 center">
   <header class="mb5">
-    <h1 class="f3 f2-ns lh-title mt0 mb3">Series</h1>
+    <h1 class="f3 f2-ns lh-title mt0 mb3">{{ ui.pages.series.heading }}</h1>
     <p class="f5 f4-ns lh-copy mt0 mb0 theme-midtone">
-      Curated reading paths through related posts. Each series starts in my
-      recommended order, and the detail page can switch to reverse or date-based
-      sorting.
+      {{ ui.pages.series.intro }}
     </p>
   </header>
 
@@ -28,7 +27,7 @@ permalink: /series/
             </a>
           </h2>
           <p class="f6 theme-midtone mt0 mb3">
-            {{ item.posts | length }} post{% if (item.posts | length) != 1 %}s{% endif %}
+            {{ item.posts | length }} {{ ui.shared.counts.post.singular if (item.posts | length) == 1 else ui.shared.counts.post.plural }}
           </p>
           {% if item.intro %}
             <p class="lh-copy mt0 mb3">
@@ -37,13 +36,13 @@ permalink: /series/
           {% endif %}
           <p class="mt0 mb0">
             <a class="link dim fw5 theme-text underline" href="{{ ('/series/' ~ item.id ~ '/') | url }}">
-              Read series
+              {{ ui.shared.series.read }}
             </a>
           </p>
         </article>
       {% endfor %}
     </div>
   {% else %}
-    <p class="theme-midtone">No series published yet.</p>
+    <p class="theme-midtone">{{ ui.pages.series.emptyMessage }}</p>
   {% endif %}
 </section>

--- a/src/series/series-page.njk
+++ b/src/series/series-page.njk
@@ -15,15 +15,15 @@ eleventyComputed:
 
 {% set seriesPosts = resolvedSeries.posts | default([]) %}
 {% set sortOptions = [
-  { id: 'curated', label: 'Curated' },
-  { id: 'reverse', label: 'Reverse' },
-  { id: 'date-asc', label: 'Oldest First' },
-  { id: 'date-desc', label: 'Newest First' }
+  { id: 'curated', label: ui.shared.series.sortOptions.curated },
+  { id: 'reverse', label: ui.shared.series.sortOptions.reverse },
+  { id: 'date-asc', label: ui.shared.series.sortOptions.dateAsc },
+  { id: 'date-desc', label: ui.shared.series.sortOptions.dateDesc }
 ] %}
 
 <section class="mw7 center" data-series-page>
   <header class="mb5">
-    <p class="f6 ttu tracked theme-midtone mt0 mb2">Series</p>
+    <p class="f6 ttu tracked theme-midtone mt0 mb2">{{ ui.shared.series.sectionLabel }}</p>
     <h1 class="f3 f2-ns lh-title mt0 mb3">{{ seriesItem.title }}</h1>
     {% if seriesItem.intro %}
       <p class="f5 f4-ns lh-copy mt0 mb4 theme-midtone">
@@ -32,7 +32,7 @@ eleventyComputed:
     {% endif %}
     <div class="flex items-center justify-between flex-wrap">
       <p class="f6 theme-midtone mt0 mb3 mb0-ns">
-        {{ seriesPosts | length }} post{% if (seriesPosts | length) != 1 %}s{% endif %}
+        {{ seriesPosts | length }} {{ ui.shared.counts.post.singular if (seriesPosts | length) == 1 else ui.shared.counts.post.plural }}
       </p>
       {% if seriesPosts | length > 1 %}
         <div class="flex flex-wrap" data-series-sort-controls>
@@ -52,7 +52,7 @@ eleventyComputed:
     </div>
     <p class="mt3 mb0">
       <a class="link dim fw5 underline theme-text" href="{{ '/series/' | url }}">
-        Back to all series
+        {{ ui.shared.series.backToAll }}
       </a>
     </p>
   </header>
@@ -100,6 +100,6 @@ eleventyComputed:
       {% endfor %}
     </ol>
   {% else %}
-    <p class="theme-midtone">This series does not have any published posts yet.</p>
+    <p class="theme-midtone">{{ ui.pages.series.detailEmptyMessage }}</p>
   {% endif %}
 </section>

--- a/src/tags.njk
+++ b/src/tags.njk
@@ -10,7 +10,7 @@ eleventyComputed:
   title: "{{ ui.pages.tags.taggedTitleTemplate | replace('{tag}', tag) }}"
 ---
 
-{% from "components/post-list.njk" import renderPostList %}
+{% from "components/post-list.njk" import renderPostList with context %}
 {% set tagItems = collections[tag] | default([]) %}
 {% set postCount = tagItems | length %}
 

--- a/src/tags.njk
+++ b/src/tags.njk
@@ -7,7 +7,7 @@ pagination:
   alias: tag
 permalink: /tags/{{ tag | slug }}/
 eleventyComputed:
-  title: Tagged “{{ tag }}”
+  title: "{{ ui.pages.tags.taggedTitleTemplate | replace('{tag}', tag) }}"
 ---
 
 {% from "components/post-list.njk" import renderPostList %}
@@ -15,9 +15,9 @@ eleventyComputed:
 {% set postCount = tagItems | length %}
 
 <section class="mw7 center">
-  <h1 class="f3 f2-ns lh-title mb2">Tagged “{{ tag }}”</h1>
+  <h1 class="f3 f2-ns lh-title mb2">{{ ui.pages.tags.taggedTitleTemplate | replace('{tag}', tag) }}</h1>
   <p class="f6 f5-ns theme-midtone mt0 mb4">
-    {{ postCount }} entr{% if postCount == 1 %}y{% else %}ies{% endif %}
+    {{ postCount }} {{ ui.shared.counts.entry.singular if postCount == 1 else ui.shared.counts.entry.plural }}
   </p>
-  {{ renderPostList(tagItems, "No entries found for this tag.") | safe }}
+  {{ renderPostList(tagItems, ui.pages.tags.emptyMessage) | safe }}
 </section>

--- a/src/timeline-calendar-weeks.njk
+++ b/src/timeline-calendar-weeks.njk
@@ -7,24 +7,25 @@ pagination:
   alias: archive
 permalink: /timeline/weeks/{{ archive.key }}/
 eleventyComputed:
-  title: "{{ timeline.calendarWeekArchive.titleTemplate | replace('{label}', archive.label) }}"
-  description: "{{ timeline.calendarWeekArchive.descriptionTemplate | replace('{rangeLabel}', archive.rangeLabel) }}"
+  title: "{{ ui.pages.timeline.calendarWeekArchive.titleTemplate | replace('{label}', archive.label) }}"
+  description: "{{ ui.pages.timeline.calendarWeekArchive.descriptionTemplate | replace('{rangeLabel}', archive.rangeLabel) }}"
 ---
 
 {% from "components/timeline-entry.njk" import renderTimelineEntry with context %}
 
+{% set timelineUi = ui.pages.timeline %}
 {% set timelineEntries = collections.timeline | default([]) %}
 {% set logItems = archive.entries | reverse %}
 
 <section class="mw7">
   <p class="f6 theme-midtone mt0 mb3">
-    <a href="/timeline/">{{ timeline.labels.root }}</a> /
-    <a href="/timeline/weeks/">{{ timeline.labels.weeks }}</a>
+    <a href="/timeline/">{{ timelineUi.labels.root }}</a> /
+    <a href="/timeline/weeks/">{{ timelineUi.labels.weeks }}</a>
   </p>
   <h1 class="f3 f2-ns lh-title mt0 mb2">{{ archive.label }}</h1>
   <p class="f6 f5-ns theme-midtone mt0 mb4">
     {{ archive.rangeLabel }} ·
-    {{ archive.entries | length }} {{ timeline.entryCount.singular if archive.entries | length == 1 else timeline.entryCount.plural }}
+    {{ archive.entries | length }} {{ timelineUi.entryCount.singular if archive.entries | length == 1 else timelineUi.entryCount.plural }}
   </p>
 
   {% if logItems | length %}
@@ -34,6 +35,6 @@ eleventyComputed:
       {% endfor %}
     </div>
   {% else %}
-    <p class="theme-midtone">{{ timeline.emptyMessages.calendarWeekArchive }}</p>
+    <p class="theme-midtone">{{ timelineUi.emptyMessages.calendarWeekArchive }}</p>
   {% endif %}
 </section>

--- a/src/timeline-calendar-weeks.njk
+++ b/src/timeline-calendar-weeks.njk
@@ -7,8 +7,8 @@ pagination:
   alias: archive
 permalink: /timeline/weeks/{{ archive.key }}/
 eleventyComputed:
-  title: "Timeline: {{ archive.label }}"
-  description: "Timeline entries from {{ archive.rangeLabel }}."
+  title: "{{ timeline.calendarWeekArchive.titleTemplate | replace('{label}', archive.label) }}"
+  description: "{{ timeline.calendarWeekArchive.descriptionTemplate | replace('{rangeLabel}', archive.rangeLabel) }}"
 ---
 
 {% from "components/timeline-entry.njk" import renderTimelineEntry with context %}
@@ -18,13 +18,13 @@ eleventyComputed:
 
 <section class="mw7">
   <p class="f6 theme-midtone mt0 mb3">
-    <a href="/timeline/">Timeline</a> /
-    <a href="/timeline/weeks/">Weeks</a>
+    <a href="/timeline/">{{ timeline.labels.root }}</a> /
+    <a href="/timeline/weeks/">{{ timeline.labels.weeks }}</a>
   </p>
   <h1 class="f3 f2-ns lh-title mt0 mb2">{{ archive.label }}</h1>
   <p class="f6 f5-ns theme-midtone mt0 mb4">
     {{ archive.rangeLabel }} ·
-    {{ archive.entries | length }} entr{% if archive.entries | length == 1 %}y{% else %}ies{% endif %}
+    {{ archive.entries | length }} {{ timeline.entryCount.singular if archive.entries | length == 1 else timeline.entryCount.plural }}
   </p>
 
   {% if logItems | length %}
@@ -34,6 +34,6 @@ eleventyComputed:
       {% endfor %}
     </div>
   {% else %}
-    <p class="theme-midtone">No timeline entries for this calendar week.</p>
+    <p class="theme-midtone">{{ timeline.emptyMessages.calendarWeekArchive }}</p>
   {% endif %}
 </section>

--- a/src/timeline-months-index.njk
+++ b/src/timeline-months-index.njk
@@ -3,21 +3,22 @@ layout: layouts/home.njk
 showPostHeader: false
 permalink: /timeline/months/
 eleventyComputed:
-  title: "{{ timeline.monthsIndex.title }}"
-  description: "{{ timeline.monthsIndex.description }}"
+  title: "{{ ui.pages.timeline.monthsIndex.title }}"
+  description: "{{ ui.pages.timeline.monthsIndex.description }}"
 ---
 
 {% from "components/timeline-week-pill.njk" import renderTimelineWeekPill %}
 
+{% set timelineUi = ui.pages.timeline %}
 {% set timelineMonthArchives = collections.timelineMonths | default([]) | reverse %}
 
 <section class="mw7">
   <h1 class="f3 f2-ns lh-title mt0 mb4">
-    <a class="link dim theme-text" href="/timeline/">{{ timeline.labels.root }}</a>
+    <a class="link dim theme-text" href="/timeline/">{{ timelineUi.labels.root }}</a>
   </h1>
-  <h2 class="f3 f2-ns lh-title mt0 mb2">{{ timeline.monthsIndex.title }}</h2>
+  <h2 class="f3 f2-ns lh-title mt0 mb2">{{ timelineUi.monthsIndex.title }}</h2>
   <p class="f6 f5-ns theme-midtone mt0 mb4">
-    {{ timeline.monthsIndex.intro }}
+    {{ timelineUi.monthsIndex.intro }}
   </p>
 
   {% if timelineMonthArchives | length %}
@@ -26,7 +27,7 @@ eleventyComputed:
         <section class="{% if not loop.first %}mt5{% endif %}">
           <h2 class="f4 f3-ns lh-title mt0 mb2">{{ month.label }}</h2>
           <p class="f6 theme-midtone mt0 mb3">
-            {{ month.entries | length }} {{ timeline.entryCount.singular if month.entries | length == 1 else timeline.entryCount.plural }}
+            {{ month.entries | length }} {{ timelineUi.entryCount.singular if month.entries | length == 1 else timelineUi.entryCount.plural }}
           </p>
 
           <div class="mb3">
@@ -46,6 +47,6 @@ eleventyComputed:
       {% endfor %}
     </div>
   {% else %}
-    <p class="theme-midtone">{{ timeline.emptyMessages.monthsIndex }}</p>
+    <p class="theme-midtone">{{ timelineUi.emptyMessages.monthsIndex }}</p>
   {% endif %}
 </section>

--- a/src/timeline-months-index.njk
+++ b/src/timeline-months-index.njk
@@ -1,9 +1,10 @@
 ---
 layout: layouts/home.njk
-title: Timeline Months
-description: Timeline entries grouped into monthly archive pages.
 showPostHeader: false
 permalink: /timeline/months/
+eleventyComputed:
+  title: "{{ timeline.monthsIndex.title }}"
+  description: "{{ timeline.monthsIndex.description }}"
 ---
 
 {% from "components/timeline-week-pill.njk" import renderTimelineWeekPill %}
@@ -12,11 +13,11 @@ permalink: /timeline/months/
 
 <section class="mw7">
   <h1 class="f3 f2-ns lh-title mt0 mb4">
-    <a class="link dim theme-text" href="/timeline/">Timeline</a>
+    <a class="link dim theme-text" href="/timeline/">{{ timeline.labels.root }}</a>
   </h1>
-  <h2 class="f3 f2-ns lh-title mt0 mb2">Timeline Months</h2>
+  <h2 class="f3 f2-ns lh-title mt0 mb2">{{ timeline.monthsIndex.title }}</h2>
   <p class="f6 f5-ns theme-midtone mt0 mb4">
-    Monthly archive pages for the timeline.
+    {{ timeline.monthsIndex.intro }}
   </p>
 
   {% if timelineMonthArchives | length %}
@@ -25,7 +26,7 @@ permalink: /timeline/months/
         <section class="{% if not loop.first %}mt5{% endif %}">
           <h2 class="f4 f3-ns lh-title mt0 mb2">{{ month.label }}</h2>
           <p class="f6 theme-midtone mt0 mb3">
-            {{ month.entries | length }} entr{% if month.entries | length == 1 %}y{% else %}ies{% endif %}
+            {{ month.entries | length }} {{ timeline.entryCount.singular if month.entries | length == 1 else timeline.entryCount.plural }}
           </p>
 
           <div class="mb3">
@@ -45,6 +46,6 @@ permalink: /timeline/months/
       {% endfor %}
     </div>
   {% else %}
-    <p class="theme-midtone">No timeline months yet.</p>
+    <p class="theme-midtone">{{ timeline.emptyMessages.monthsIndex }}</p>
   {% endif %}
 </section>

--- a/src/timeline-months.njk
+++ b/src/timeline-months.njk
@@ -7,37 +7,38 @@ pagination:
   alias: archive
 permalink: /timeline/months/{{ archive.key }}/
 eleventyComputed:
-  title: "{{ timeline.monthArchive.titleTemplate | replace('{label}', archive.label) }}"
-  description: "{{ timeline.monthArchive.descriptionTemplate | replace('{label}', archive.label) }}"
+  title: "{{ ui.pages.timeline.monthArchive.titleTemplate | replace('{label}', archive.label) }}"
+  description: "{{ ui.pages.timeline.monthArchive.descriptionTemplate | replace('{label}', archive.label) }}"
 ---
 
 {% from "components/timeline-entry.njk" import renderTimelineEntry with context %}
 {% from "components/timeline-week-pill.njk" import renderTimelineWeekPill %}
 
+{% set timelineUi = ui.pages.timeline %}
 {% set timelineEntries = collections.timeline | default([]) %}
 {% set logItems = archive.entries | reverse %}
 
 <section class="mw7">
   <p class="f6 theme-midtone mt0 mb3">
-    <a href="/timeline/">{{ timeline.labels.root }}</a> /
-    <a href="/timeline/months/">{{ timeline.labels.months }}</a>
+    <a href="/timeline/">{{ timelineUi.labels.root }}</a> /
+    <a href="/timeline/months/">{{ timelineUi.labels.months }}</a>
   </p>
   <h1 class="f3 f2-ns lh-title mt0 mb2">{{ archive.label }}</h1>
   <p class="f6 f5-ns theme-midtone mt0 mb4">
-    {{ archive.entries | length }} {{ timeline.entryCount.singular if archive.entries | length == 1 else timeline.entryCount.plural }}
-    {{ timeline.monthArchive.countSuffix }}
+    {{ archive.entries | length }} {{ timelineUi.entryCount.singular if archive.entries | length == 1 else timelineUi.entryCount.plural }}
+    {{ timelineUi.monthArchive.countSuffix }}
   </p>
 
   {% if archive.weeks | length %}
     <nav class="mb4">
-      <p class="f6 theme-midtone mt0 mb2">{{ timeline.monthArchive.monthBandedWeeksHeading }}</p>
+      <p class="f6 theme-midtone mt0 mb2">{{ timelineUi.monthArchive.monthBandedWeeksHeading }}</p>
       <div class="flex flex-wrap">
         {% for week in archive.weeks %}
           {{ renderTimelineWeekPill(week, week.entryCount) }}
         {% endfor %}
       </div>
       <p class="f7 theme-midtone mt2 mb0">
-        {{ timeline.monthArchive.calendarWeeksNoteHtml | safe }}
+        {{ timelineUi.monthArchive.calendarWeeksNoteHtml | safe }}
       </p>
     </nav>
   {% endif %}
@@ -49,6 +50,6 @@ eleventyComputed:
       {% endfor %}
     </div>
   {% else %}
-    <p class="theme-midtone">{{ timeline.emptyMessages.monthArchive }}</p>
+    <p class="theme-midtone">{{ timelineUi.emptyMessages.monthArchive }}</p>
   {% endif %}
 </section>

--- a/src/timeline-months.njk
+++ b/src/timeline-months.njk
@@ -7,8 +7,8 @@ pagination:
   alias: archive
 permalink: /timeline/months/{{ archive.key }}/
 eleventyComputed:
-  title: "Timeline: {{ archive.label }}"
-  description: "Timeline entries from {{ archive.label }}."
+  title: "{{ timeline.monthArchive.titleTemplate | replace('{label}', archive.label) }}"
+  description: "{{ timeline.monthArchive.descriptionTemplate | replace('{label}', archive.label) }}"
 ---
 
 {% from "components/timeline-entry.njk" import renderTimelineEntry with context %}
@@ -19,25 +19,25 @@ eleventyComputed:
 
 <section class="mw7">
   <p class="f6 theme-midtone mt0 mb3">
-    <a href="/timeline/">Timeline</a> /
-    <a href="/timeline/months/">Months</a>
+    <a href="/timeline/">{{ timeline.labels.root }}</a> /
+    <a href="/timeline/months/">{{ timeline.labels.months }}</a>
   </p>
   <h1 class="f3 f2-ns lh-title mt0 mb2">{{ archive.label }}</h1>
   <p class="f6 f5-ns theme-midtone mt0 mb4">
-    {{ archive.entries | length }} entr{% if archive.entries | length == 1 %}y{% else %}ies{% endif %}
-    in this month.
+    {{ archive.entries | length }} {{ timeline.entryCount.singular if archive.entries | length == 1 else timeline.entryCount.plural }}
+    {{ timeline.monthArchive.countSuffix }}
   </p>
 
   {% if archive.weeks | length %}
     <nav class="mb4">
-      <p class="f6 theme-midtone mt0 mb2">Month-banded weeks in this month</p>
+      <p class="f6 theme-midtone mt0 mb2">{{ timeline.monthArchive.monthBandedWeeksHeading }}</p>
       <div class="flex flex-wrap">
         {% for week in archive.weeks %}
           {{ renderTimelineWeekPill(week, week.entryCount) }}
         {% endfor %}
       </div>
       <p class="f7 theme-midtone mt2 mb0">
-        Calendar weeks also live under <code>/timeline/weeks/</code>, using keys like <code>2026-W16</code>.
+        {{ timeline.monthArchive.calendarWeeksNoteHtml | safe }}
       </p>
     </nav>
   {% endif %}
@@ -49,6 +49,6 @@ eleventyComputed:
       {% endfor %}
     </div>
   {% else %}
-    <p class="theme-midtone">No timeline entries for this month.</p>
+    <p class="theme-midtone">{{ timeline.emptyMessages.monthArchive }}</p>
   {% endif %}
 </section>

--- a/src/timeline-tags.njk
+++ b/src/timeline-tags.njk
@@ -7,23 +7,24 @@ pagination:
   alias: archive
 permalink: /timeline/{{ archive.slug }}/
 eleventyComputed:
-  title: "{{ timeline.tagArchive.titleTemplate | replace('{tag}', archive.tag) }}"
-  description: "{{ timeline.tagArchive.descriptionTemplate | replace('{tag}', archive.tag) }}"
+  title: "{{ ui.pages.timeline.tagArchive.titleTemplate | replace('{tag}', archive.tag) }}"
+  description: "{{ ui.pages.timeline.tagArchive.descriptionTemplate | replace('{tag}', archive.tag) }}"
 ---
 
 {% from "components/timeline-entry.njk" import renderTimelineEntry with context %}
 
+{% set timelineUi = ui.pages.timeline %}
 {% set timelineEntries = collections.timeline | default([]) %}
 {% set logItems = archive.entries | reverse %}
 
 <section class="mw7">
   <h1 class="f3 f2-ns lh-title mt0 mb4">
-    <a class="link dim theme-text" href="/timeline/">{{ timeline.labels.root }}</a>
+    <a class="link dim theme-text" href="/timeline/">{{ timelineUi.labels.root }}</a>
   </h1>
   <h2 class="f3 f2-ns lh-title mt0 mb2">#{{ archive.tag }}</h2>
   <p class="f6 f5-ns theme-midtone mt0 mb4">
-    {{ archive.entries | length }} {{ timeline.entryCount.singular if archive.entries | length == 1 else timeline.entryCount.plural }}
-    {{ timeline.tagArchive.countSuffix }}
+    {{ archive.entries | length }} {{ timelineUi.entryCount.singular if archive.entries | length == 1 else timelineUi.entryCount.plural }}
+    {{ timelineUi.tagArchive.countSuffix }}
   </p>
 
   {% if logItems | length %}
@@ -33,6 +34,6 @@ eleventyComputed:
       {% endfor %}
     </div>
   {% else %}
-    <p class="theme-midtone">{{ timeline.emptyMessages.tagArchive }}</p>
+    <p class="theme-midtone">{{ timelineUi.emptyMessages.tagArchive }}</p>
   {% endif %}
 </section>

--- a/src/timeline-tags.njk
+++ b/src/timeline-tags.njk
@@ -7,8 +7,8 @@ pagination:
   alias: archive
 permalink: /timeline/{{ archive.slug }}/
 eleventyComputed:
-  title: 'Timeline: {{ archive.tag }}'
-  description: 'Timeline entries tagged {{ archive.tag }}, in chronological context.'
+  title: "{{ timeline.tagArchive.titleTemplate | replace('{tag}', archive.tag) }}"
+  description: "{{ timeline.tagArchive.descriptionTemplate | replace('{tag}', archive.tag) }}"
 ---
 
 {% from "components/timeline-entry.njk" import renderTimelineEntry with context %}
@@ -18,12 +18,12 @@ eleventyComputed:
 
 <section class="mw7">
   <h1 class="f3 f2-ns lh-title mt0 mb4">
-    <a class="link dim theme-text" href="/timeline/">Timeline</a>
+    <a class="link dim theme-text" href="/timeline/">{{ timeline.labels.root }}</a>
   </h1>
   <h2 class="f3 f2-ns lh-title mt0 mb2">#{{ archive.tag }}</h2>
   <p class="f6 f5-ns theme-midtone mt0 mb4">
-    {{ archive.entries | length }} entr{% if archive.entries | length == 1 %}y{% else %}ies{% endif %}
-    following this thread through the timeline.
+    {{ archive.entries | length }} {{ timeline.entryCount.singular if archive.entries | length == 1 else timeline.entryCount.plural }}
+    {{ timeline.tagArchive.countSuffix }}
   </p>
 
   {% if logItems | length %}
@@ -33,6 +33,6 @@ eleventyComputed:
       {% endfor %}
     </div>
   {% else %}
-    <p class="theme-midtone">No timeline entries for this topic yet.</p>
+    <p class="theme-midtone">{{ timeline.emptyMessages.tagArchive }}</p>
   {% endif %}
 </section>

--- a/src/timeline-weeks-index.njk
+++ b/src/timeline-weeks-index.njk
@@ -1,9 +1,10 @@
 ---
 layout: layouts/home.njk
-title: Timeline Weeks
-description: Timeline entries grouped into both month-banded and ISO calendar weeks.
 showPostHeader: false
 permalink: /timeline/weeks/
+eleventyComputed:
+  title: "{{ timeline.weeksIndex.title }}"
+  description: "{{ timeline.weeksIndex.description }}"
 ---
 
 {% from "components/timeline-week-pill.njk" import renderTimelineWeekPill %}
@@ -13,11 +14,11 @@ permalink: /timeline/weeks/
 
 <section class="mw7">
   <h1 class="f3 f2-ns lh-title mt0 mb4">
-    <a class="link dim theme-text" href="/timeline/">Timeline</a>
+    <a class="link dim theme-text" href="/timeline/">{{ timeline.labels.root }}</a>
   </h1>
-  <h2 class="f3 f2-ns lh-title mt0 mb2">Timeline Weeks</h2>
+  <h2 class="f3 f2-ns lh-title mt0 mb2">{{ timeline.weeksIndex.title }}</h2>
   <p class="f6 f5-ns theme-midtone mt0 mb4">
-    Month-banded weeks and ISO calendar week pages grouped by month. ISO weeks that cross a month boundary appear in both months.
+    {{ timeline.weeksIndex.intro }}
   </p>
 
   {% if timelineMonthArchives | length %}
@@ -30,7 +31,7 @@ permalink: /timeline/weeks/
 
           {% if month.weeks | length %}
             <div class="mb3">
-              <p class="f6 theme-midtone mt0 mb2">Month-banded weeks</p>
+              <p class="f6 theme-midtone mt0 mb2">{{ timeline.weeksIndex.monthBandedWeeksHeading }}</p>
               <div class="flex flex-wrap">
                 {% for week in month.weeks | reverse %}
                   {{ renderTimelineWeekPill(week, week.entryCount) }}
@@ -40,7 +41,7 @@ permalink: /timeline/weeks/
           {% endif %}
 
           <div>
-            <p class="f6 theme-midtone mt0 mb2">ISO calendar weeks</p>
+            <p class="f6 theme-midtone mt0 mb2">{{ timeline.weeksIndex.calendarWeeksHeading }}</p>
             <div class="flex flex-wrap">
               {% for week in calendarWeekArchives %}
                 {% if week.startMonthKey == month.key or week.endMonthKey == month.key %}
@@ -53,6 +54,6 @@ permalink: /timeline/weeks/
       {% endfor %}
     </div>
   {% else %}
-    <p class="theme-midtone">No timeline weeks yet.</p>
+    <p class="theme-midtone">{{ timeline.emptyMessages.weeksIndex }}</p>
   {% endif %}
 </section>

--- a/src/timeline-weeks-index.njk
+++ b/src/timeline-weeks-index.njk
@@ -3,22 +3,23 @@ layout: layouts/home.njk
 showPostHeader: false
 permalink: /timeline/weeks/
 eleventyComputed:
-  title: "{{ timeline.weeksIndex.title }}"
-  description: "{{ timeline.weeksIndex.description }}"
+  title: "{{ ui.pages.timeline.weeksIndex.title }}"
+  description: "{{ ui.pages.timeline.weeksIndex.description }}"
 ---
 
 {% from "components/timeline-week-pill.njk" import renderTimelineWeekPill %}
 
+{% set timelineUi = ui.pages.timeline %}
 {% set timelineMonthArchives = collections.timelineMonths | default([]) | reverse %}
 {% set calendarWeekArchives = collections.timelineCalendarWeeks | default([]) | reverse %}
 
 <section class="mw7">
   <h1 class="f3 f2-ns lh-title mt0 mb4">
-    <a class="link dim theme-text" href="/timeline/">{{ timeline.labels.root }}</a>
+    <a class="link dim theme-text" href="/timeline/">{{ timelineUi.labels.root }}</a>
   </h1>
-  <h2 class="f3 f2-ns lh-title mt0 mb2">{{ timeline.weeksIndex.title }}</h2>
+  <h2 class="f3 f2-ns lh-title mt0 mb2">{{ timelineUi.weeksIndex.title }}</h2>
   <p class="f6 f5-ns theme-midtone mt0 mb4">
-    {{ timeline.weeksIndex.intro }}
+    {{ timelineUi.weeksIndex.intro }}
   </p>
 
   {% if timelineMonthArchives | length %}
@@ -31,7 +32,7 @@ eleventyComputed:
 
           {% if month.weeks | length %}
             <div class="mb3">
-              <p class="f6 theme-midtone mt0 mb2">{{ timeline.weeksIndex.monthBandedWeeksHeading }}</p>
+              <p class="f6 theme-midtone mt0 mb2">{{ timelineUi.weeksIndex.monthBandedWeeksHeading }}</p>
               <div class="flex flex-wrap">
                 {% for week in month.weeks | reverse %}
                   {{ renderTimelineWeekPill(week, week.entryCount) }}
@@ -41,7 +42,7 @@ eleventyComputed:
           {% endif %}
 
           <div>
-            <p class="f6 theme-midtone mt0 mb2">{{ timeline.weeksIndex.calendarWeeksHeading }}</p>
+            <p class="f6 theme-midtone mt0 mb2">{{ timelineUi.weeksIndex.calendarWeeksHeading }}</p>
             <div class="flex flex-wrap">
               {% for week in calendarWeekArchives %}
                 {% if week.startMonthKey == month.key or week.endMonthKey == month.key %}
@@ -54,6 +55,6 @@ eleventyComputed:
       {% endfor %}
     </div>
   {% else %}
-    <p class="theme-midtone">{{ timeline.emptyMessages.weeksIndex }}</p>
+    <p class="theme-midtone">{{ timelineUi.emptyMessages.weeksIndex }}</p>
   {% endif %}
 </section>

--- a/src/timeline-weeks.njk
+++ b/src/timeline-weeks.njk
@@ -7,8 +7,8 @@ pagination:
   alias: archive
 permalink: /timeline/weeks/{{ archive.key }}/
 eleventyComputed:
-  title: "Timeline: {{ archive.label }}"
-  description: "Timeline entries from {{ archive.rangeLabel }}."
+  title: "{{ timeline.weekArchive.titleTemplate | replace('{label}', archive.label) }}"
+  description: "{{ timeline.weekArchive.descriptionTemplate | replace('{rangeLabel}', archive.rangeLabel) }}"
 ---
 
 {% from "components/timeline-entry.njk" import renderTimelineEntry with context %}
@@ -18,13 +18,13 @@ eleventyComputed:
 
 <section class="mw7">
   <p class="f6 theme-midtone mt0 mb3">
-    <a href="/timeline/">Timeline</a> /
+    <a href="/timeline/">{{ timeline.labels.root }}</a> /
     <a href="/timeline/months/{{ archive.monthKey }}/">{{ archive.monthLabel }}</a>
   </p>
   <h1 class="f3 f2-ns lh-title mt0 mb2">{{ archive.label }}</h1>
   <p class="f6 f5-ns theme-midtone mt0 mb4">
     {{ archive.rangeLabel }} ·
-    {{ archive.entries | length }} entr{% if archive.entries | length == 1 %}y{% else %}ies{% endif %}
+    {{ archive.entries | length }} {{ timeline.entryCount.singular if archive.entries | length == 1 else timeline.entryCount.plural }}
   </p>
 
   {% if logItems | length %}
@@ -34,6 +34,6 @@ eleventyComputed:
       {% endfor %}
     </div>
   {% else %}
-    <p class="theme-midtone">No timeline entries for this week.</p>
+    <p class="theme-midtone">{{ timeline.emptyMessages.weekArchive }}</p>
   {% endif %}
 </section>

--- a/src/timeline-weeks.njk
+++ b/src/timeline-weeks.njk
@@ -7,24 +7,25 @@ pagination:
   alias: archive
 permalink: /timeline/weeks/{{ archive.key }}/
 eleventyComputed:
-  title: "{{ timeline.weekArchive.titleTemplate | replace('{label}', archive.label) }}"
-  description: "{{ timeline.weekArchive.descriptionTemplate | replace('{rangeLabel}', archive.rangeLabel) }}"
+  title: "{{ ui.pages.timeline.weekArchive.titleTemplate | replace('{label}', archive.label) }}"
+  description: "{{ ui.pages.timeline.weekArchive.descriptionTemplate | replace('{rangeLabel}', archive.rangeLabel) }}"
 ---
 
 {% from "components/timeline-entry.njk" import renderTimelineEntry with context %}
 
+{% set timelineUi = ui.pages.timeline %}
 {% set timelineEntries = collections.timeline | default([]) %}
 {% set logItems = archive.entries | reverse %}
 
 <section class="mw7">
   <p class="f6 theme-midtone mt0 mb3">
-    <a href="/timeline/">{{ timeline.labels.root }}</a> /
+    <a href="/timeline/">{{ timelineUi.labels.root }}</a> /
     <a href="/timeline/months/{{ archive.monthKey }}/">{{ archive.monthLabel }}</a>
   </p>
   <h1 class="f3 f2-ns lh-title mt0 mb2">{{ archive.label }}</h1>
   <p class="f6 f5-ns theme-midtone mt0 mb4">
     {{ archive.rangeLabel }} ·
-    {{ archive.entries | length }} {{ timeline.entryCount.singular if archive.entries | length == 1 else timeline.entryCount.plural }}
+    {{ archive.entries | length }} {{ timelineUi.entryCount.singular if archive.entries | length == 1 else timelineUi.entryCount.plural }}
   </p>
 
   {% if logItems | length %}
@@ -34,6 +35,6 @@ eleventyComputed:
       {% endfor %}
     </div>
   {% else %}
-    <p class="theme-midtone">{{ timeline.emptyMessages.weekArchive }}</p>
+    <p class="theme-midtone">{{ timelineUi.emptyMessages.weekArchive }}</p>
   {% endif %}
 </section>

--- a/src/timeline.njk
+++ b/src/timeline.njk
@@ -4,12 +4,13 @@ ogImage: /assets/og/timeline.png
 showPostHeader: false
 permalink: /timeline/
 eleventyComputed:
-  title: "{{ timeline.title }}"
-  description: "{{ timeline.description }}"
+  title: "{{ ui.pages.timeline.title }}"
+  description: "{{ ui.pages.timeline.description }}"
 ---
 
 {% from "components/timeline-entry.njk" import renderTimelineEntry with context %}
 
+{% set timelineUi = ui.pages.timeline %}
 {% set timelineEntries = collections.timeline | default([]) %}
 {% set timelineTagArchives = collections.timelineTagArchives | default([]) %}
 {% set featuredTimelineTags = timeline.featuredTags | default([]) %}
@@ -17,11 +18,11 @@ eleventyComputed:
 
 <section class="mw7">
   <h1 class="f3 f2-ns lh-title mt0 mb4">
-    <a class="link dim theme-text" href="/timeline/">{{ timeline.labels.root }}</a>
+    <a class="link dim theme-text" href="/timeline/">{{ timelineUi.labels.root }}</a>
   </h1>
 
   {% if featuredTimelineTags | length and timelineTagArchives | length %}
-    <nav class="mb4" aria-label="{{ timeline.featuredTopicsAriaLabel }}">
+    <nav class="mb4" aria-label="{{ timelineUi.featuredTopicsAriaLabel }}">
       <div class="flex flex-wrap">
         {% for featuredTag in featuredTimelineTags %}
           {% for archive in timelineTagArchives %}
@@ -41,6 +42,6 @@ eleventyComputed:
       {% endfor %}
     </div>
   {% else %}
-    <p class="theme-midtone">{{ timeline.emptyMessages.mainHtml | safe }}</p>
+    <p class="theme-midtone">{{ timelineUi.emptyMessages.mainHtml | safe }}</p>
   {% endif %}
 </section>

--- a/src/timeline.njk
+++ b/src/timeline.njk
@@ -1,10 +1,11 @@
 ---
 layout: layouts/home.njk
-title: Timeline
-description: A personal timeline log, color-coded by entry type.
 ogImage: /assets/og/timeline.png
 showPostHeader: false
 permalink: /timeline/
+eleventyComputed:
+  title: "{{ timeline.title }}"
+  description: "{{ timeline.description }}"
 ---
 
 {% from "components/timeline-entry.njk" import renderTimelineEntry with context %}
@@ -16,11 +17,11 @@ permalink: /timeline/
 
 <section class="mw7">
   <h1 class="f3 f2-ns lh-title mt0 mb4">
-    <a class="link dim theme-text" href="/timeline/">Timeline</a>
+    <a class="link dim theme-text" href="/timeline/">{{ timeline.labels.root }}</a>
   </h1>
 
   {% if featuredTimelineTags | length and timelineTagArchives | length %}
-    <nav class="mb4" aria-label="Featured timeline topics">
+    <nav class="mb4" aria-label="{{ timeline.featuredTopicsAriaLabel }}">
       <div class="flex flex-wrap">
         {% for featuredTag in featuredTimelineTags %}
           {% for archive in timelineTagArchives %}
@@ -40,6 +41,6 @@ permalink: /timeline/
       {% endfor %}
     </div>
   {% else %}
-    <p class="theme-midtone">No entries yet. Add a markdown file to <code>timeline/</code> to get started.</p>
+    <p class="theme-midtone">{{ timeline.emptyMessages.mainHtml | safe }}</p>
   {% endif %}
 </section>


### PR DESCRIPTION
Summary
- centralize user-facing template copy in _data/ui.yaml
- move timeline labels, empty states, and category color metadata into _data/timeline.yaml
- update Eleventy timeline handling to read category tags from data instead of hardcoded literals
- document the new timeline data contract and add a parked plan for multi-stream timelines
- restore the original paginated home title separator after comparing generated output

Verification
- npm run build
- ELEVENTY_ENV=development ./node_modules/.bin/eleventy
- compared generated _site output between main and this branch in both production and development modes