### PR TITLE
docs(testing): add testing guide and update plan

### DIFF
--- a/docs/plans/0003-test-suite.md
+++ b/docs/plans/0003-test-suite.md
@@ -1,0 +1,289 @@
+# 0003 - Test Suite
+
+**Status:** In Progress
+**Approach:** Layered tests (data invariants, contract, fixtures, snapshots, unit, smoke)
+
+---
+
+## Overview
+
+The project has grown without an engineering test baseline. Before refactoring
+`eleventy.config.js` into smaller modules and continuing to add features, we
+want a layered test suite that locks in current behavior, catches regressions
+in rendered output and relational data, and stays cheap to maintain.
+
+Tests are organized by what they verify, not by what they import:
+
+- **data invariants** — checks the build itself won't catch
+- **contract** — assertions on real built HTML for every page type
+- **fixtures** — tiny Eleventy sites for relational and negative-path scenarios
+- **snapshots** — small, normalized HTML fragments for reusable components
+- **unit** — pure-function tests on helpers extracted from `eleventy.config.js`
+- **e2e smoke** — a thin Playwright layer for things only a real browser sees
+
+Current rollout status:
+
+- Phases 1 through 5 are substantially complete.
+- Phase 6 is in progress.
+- Phase 7 is blocked on further Phase 6 extraction work.
+- Phase 8 has not started.
+
+---
+
+## Goals
+
+- Lock in current behavior before refactoring `eleventy.config.js`.
+- Cover every page type the site renders, not just timeline/projects.
+- Verify timeline parent/child relational rendering without Playwright.
+- Keep tests fast, deterministic, and easy to review on failure.
+- Make snapshots small enough to read in a PR diff.
+
+## Non-Goals
+
+- Schema tests for data files whose breakage the build already surfaces
+  (`me.yaml`, `themes.yaml`, `sidebarNav.yaml`, `site.yaml`).
+- Visual regression testing.
+- Full accessibility sweep (axe) and HTML validator passes.
+- OG image pixel comparisons.
+
+---
+
+## Tooling
+
+- **Test runner:** `vitest` (snapshot UX, watch mode, fast).
+- **DOM parsing:** `linkedom` (lighter than jsdom for static HTML).
+- **Eleventy fixtures:** Eleventy programmatic API
+  (`new Eleventy(input, output, { configPath }).toJSON()`).
+- **Browser:** Playwright, one spec file.
+- Existing `npm run build` remains the first CI gate.
+
+---
+
+## Directory layout
+
+```
+test/
+  data/
+    invariants.test.js
+  unit/
+    timeline-refs.test.js
+    timeline-graph.test.js
+    timeline-validate.test.js
+    timeline-archives.test.js
+    timeline-categories.test.js
+    excerpt.test.js
+    code-block.test.js
+    todo-blockquote.test.js
+    github-embed.test.js
+    link-check.test.js
+    excluded-content.test.js
+    fingerprint.test.js
+  contract/
+    home.test.js
+    about.test.js
+    notes.test.js
+    hidden-notes.test.js
+    drafts.test.js
+    projects.test.js
+    timeline-index.test.js
+    timeline-entry.test.js
+    timeline-months.test.js
+    timeline-weeks.test.js
+    timeline-calendar-weeks.test.js
+    timeline-tag-archive.test.js
+    tags.test.js
+    all-tags.test.js
+    tag-pagination.test.js
+    series.test.js
+    feed.test.js
+    no-unresolved-templates.test.js
+    no-empty-anchors.test.js
+  fixtures/
+    timeline-linear-thread/
+    timeline-branching/
+    timeline-deep-tree/
+    timeline-earlier-thread/
+    timeline-orphan-parent/
+    timeline-cycle/
+    timeline-self-parent/
+    timeline-tag-collision/
+    timeline-reserved-slug/
+    timeline-unquoted-date/
+    timeline-multi-category/
+  fixtures.test.js
+  snapshots/
+    project-card.test.js
+    tag-chip.test.js
+    timeline-entry.test.js
+    timeline-week-pill.test.js
+    post-list-item.test.js
+    timeline-entry-body.test.js
+    post-body.test.js
+  e2e/
+    smoke.spec.js
+  helpers/
+    build-once.js
+    normalize-html.js
+    parse.js
+playwright.config.js
+vitest.config.js
+```
+
+---
+
+## Helper extraction plan (for unit tests)
+
+The unit layer assumes `eleventy.config.js` is split into focused modules. The
+extraction should preserve current behavior — contract, fixtures, and snapshot
+tests provide the safety net.
+
+- `lib/timeline/refs.js` — `normalizeTimelineRef`, `getTimelineEntryRef`, `getTimelineParentRef`
+- `lib/timeline/graph.js` — `buildTimelineEntryMap`, `buildTimelineChildMap`, ancestors, earlier-thread, descendant count, descendant tree
+- `lib/timeline/validate.js` — `validateTimelineEntryRelationships`, date/time quoting check
+- `lib/timeline/sort.js` — `getTimelineSortKey`, sorted-entries helper
+- `lib/timeline/archives.js` — month/week/calendar-week/tag archive builders, `getTimelineTopicTags`, reserved/excluded tag rules
+- `lib/timeline/categories.js` — `getTimelineEntryType`, `getTimelineTypeTags`
+- `lib/markdown/code-block.js` — `renderMarkdownCodeBlock`, `highlightCode`, `normalizeLanguage`, `countCodeLines`
+- `lib/markdown/todo-blockquote.js` — `markTodoBlockquotes`
+- `lib/markdown/github-embed.js` — `parseBlobUrl`, `trimSharedIndent`, `guessLanguageByExt`
+- `lib/assets/fingerprint.js` — `buildAssetUrl`, `emitFingerprintedAssets`
+- `lib/build/link-check.js` — the `eleventy.after` broken-link scanner
+- `lib/eleventy/excluded-content.js` — `isTestingOnlyContent` + draft exclusion logic
+
+---
+
+## Execution order
+
+1. Bootstrap tooling (vitest, linkedom, scripts, helpers).
+2. Data invariants.
+3. Contract tests against the real build (largest single value add).
+4. Snapshots (reuse the same build).
+5. Fixture-based relational + negative-path tests.
+6. Refactor `eleventy.config.js` into `lib/` modules. Existing layers must stay green.
+7. Unit tests written alongside each extraction.
+8. Playwright smoke layer.
+
+---
+
+## Todo
+
+### Phase 1 — Tooling bootstrap
+
+- [x] Add `vitest` and `linkedom` to devDependencies.
+- [x] Add `test`, `test:watch`, `test:e2e` scripts to `package.json`.
+- [x] Create `vitest.config.js` (node environment, include `test/**`).
+- [x] Add `test/helpers/build-once.js` (runs `npm run build` once per suite, caches result).
+- [x] Add `test/helpers/parse.js` (linkedom wrapper for built HTML by URL).
+- [x] Add `test/helpers/normalize-html.js` (strip asset fingerprints, today's date, OG filenames).
+- [ ] Wire CI to run `npm run build && npm test`.
+
+### Phase 2 — Data invariants
+
+- [x] `test/data/invariants.test.js`:
+  - [x] timeline category `tag` values are unique
+  - [x] timeline category `color` matches `/^#[0-9a-f]{6}$/i`
+  - [x] `featuredTags` is an array of strings (if present)
+  - [x] `series.yaml` entries reference real post/note slugs
+
+### Phase 3 — Contract tests (against real build)
+
+- [x] `home.test.js` — page 1 + page 2 render; post list items present; prev/next pagination works; titles stable.
+- [x] `about.test.js` — `me.yaml` fields render; no unresolved template output.
+- [x] `notes.test.js` — non-hidden notes listed; hidden notes absent.
+- [x] `hidden-notes.test.js` — hidden notes listed; not present in `sidebarNav.yaml` nav.
+- [x] `drafts.test.js` — drafts page exists in dev; (optionally) absent/empty in production.
+- [x] `projects.test.js` — cards present; `Link` and `GitHub` anchors non-empty where data provides `url`/`repo`; no empty anchors.
+- [x] `timeline-index.test.js` — entries render; category color rules applied; pagination titles stable.
+- [x] `timeline-entry.test.js` — title/body/category badge for a known entry.
+- [x] `timeline-months.test.js` — `/timeline/months/` index + a known month archive; entry counts match.
+- [x] `timeline-weeks.test.js` — `/timeline/weeks/` index + a known week archive.
+- [x] `timeline-calendar-weeks.test.js` — ISO week labels; year-boundary case if present.
+- [x] `timeline-tag-archive.test.js` — topic-tag archive renders entries; reserved/excluded tags produce no archive.
+- [x] `tags.test.js` — tag groups render with sane counts; excluded tags absent.
+- [x] `all-tags.test.js` — full tag list renders.
+- [x] `tag-pagination.test.js` — paginated tag archive for a known tag.
+- [x] `series.test.js` — `/series/` index + a series page; declared entry order respected.
+- [x] `feed.test.js` — `/feed.xml` is valid XML; latest N entries present; URLs absolute.
+- [x] `no-unresolved-templates.test.js` — scan every generated HTML file; assert no literal `{{ ... }}` output.
+- [x] `no-empty-anchors.test.js` — scan every generated HTML file; assert no `<a href="..."></a>` empties.
+
+### Phase 4 — Snapshots
+
+- [x] `project-card.test.js` — variants: `url`+`repo`, `url` only, `repo` only, neither.
+- [x] `tag-chip.test.js` — plain, featured, with count.
+- [x] `timeline-entry.test.js` — one per category for color coverage; one with parent badge; one with children badge.
+- [x] `timeline-week-pill.test.js` — single week + multi-week range.
+- [x] `post-list-item.test.js` — note variant, post variant, with/without excerpt.
+- [x] `timeline-entry-body.test.js` — representative entry with parent + children + earlier-thread.
+- [ ] `post-body.test.js` — post with TOC, footnote, code block (collapsed + uncollapsed), `> TODO` blockquote, GitHub embed shortcode.
+
+### Phase 5 — Fixtures (Eleventy programmatic API)
+
+- [x] `timeline-linear-thread/` — A → B → C. Assert ancestors of C, descendants of A.
+- [x] `timeline-branching/` — A with children B, C. Assert sibling sort order.
+- [x] `timeline-deep-tree/` — exercises `maxDepth=2` and the `continues` flag.
+- [x] `timeline-earlier-thread/` — "earlier in thread" section content + ordering.
+- [x] `timeline-orphan-parent/` — build throws with expected message.
+- [x] `timeline-cycle/` — build throws.
+- [x] `timeline-self-parent/` — build throws.
+- [x] `timeline-tag-collision/` — tag whose slug matches an entry slug; build throws.
+- [x] `timeline-reserved-slug/` — tag named `months`/`weeks`; build throws.
+- [x] `timeline-unquoted-date/` — `validateTimelineEntryDateTimeQuotes` throws.
+- [x] `timeline-multi-category/` — entry with two category tags; first-match-wins.
+- [x] `test/fixtures.test.js` — runs each fixture via programmatic API; asserts positive cases via DOM, negative cases via thrown error message.
+
+### Phase 6 — Refactor eleventy.config.js
+
+- [x] Extract `lib/timeline/refs.js`.
+- [ ] Extract `lib/timeline/graph.js`.
+- [ ] Extract `lib/timeline/validate.js`.
+- [ ] Extract `lib/timeline/sort.js`.
+- [ ] Extract `lib/timeline/archives.js`.
+- [ ] Extract `lib/timeline/categories.js`.
+- [ ] Extract `lib/markdown/code-block.js`.
+- [ ] Extract `lib/markdown/todo-blockquote.js`.
+- [ ] Extract `lib/markdown/github-embed.js`.
+- [ ] Extract `lib/assets/fingerprint.js`.
+- [ ] Extract `lib/build/link-check.js`.
+- [ ] Extract `lib/eleventy/excluded-content.js`.
+- [ ] Confirm contract + snapshot + fixture suites stay green after each extraction.
+
+### Phase 7 — Unit tests (alongside each extraction)
+
+- [x] `timeline-refs.test.js` — trailing slash, absolute URL, relative, empty, non-string.
+- [ ] `timeline-graph.test.js` — linear, branching, deep tree with `maxDepth`/`continues`, missing parent ref.
+- [ ] `timeline-validate.test.js` — valid passes; self-parent, cycle, missing target, non-`/timeline/` ref, non-string each throw with useful messages.
+- [ ] `timeline-archives.test.js` — month/week keys; ISO week year-boundary; reserved slugs rejected; tag/entry slug collision rejected.
+- [ ] `timeline-categories.test.js` — first match wins; no match returns `default`.
+- [ ] `excerpt.test.js` — empty, plain prose, prose with code, length limits.
+- [ ] `code-block.test.js` — copy button threshold; collapse threshold; language class normalization; unknown language fallback.
+- [ ] `todo-blockquote.test.js` — production vs dev class; only blockquotes containing `TODO` tagged; case-insensitive.
+- [ ] `github-embed.test.js` — blob URL with `#L10`, `#L10-L20`, no range; indent trimming preserves blank lines.
+- [ ] `link-check.test.js` — detects broken internal links; ignores `mailto:`, hash-only, external, files with extensions.
+- [ ] `excluded-content.test.js` — testing-tagged content excluded in production, included in dev; drafts excluded in production.
+- [ ] `fingerprint.test.js` — stable hash for unchanged file; new hash on size/mtime change; query/hash preserved.
+
+### Phase 8 — Playwright smoke
+
+- [ ] Add `playwright.config.js`.
+- [ ] Add `test/e2e/smoke.spec.js`.
+- [ ] Cover a minimal browser-only smoke path for the built site.
+
+- [ ] Add `playwright` devDependency + `playwright.config.js` (uses `webServer` against pre-built `_site`).
+- [ ] `e2e/smoke.spec.js`:
+  - [ ] homepage loads; zero failed network requests; no console errors.
+  - [ ] theme toggle flips `data-theme` and persists across reload via localStorage.
+  - [ ] code block above collapse threshold shows Expand; click toggles `aria-expanded` + visible height.
+  - [ ] code block Wrap toggle flips `aria-pressed` and class.
+  - [ ] project card `Link` anchor navigates to expected URL.
+  - [ ] timeline detail page renders parent + child relationship sections.
+
+---
+
+## References
+
+- Research note: `docs/references/testing-static-generator-projects.md`
+- Eleventy Programmatic API: https://www.11ty.dev/docs/programmatic/
+- Playwright: https://playwright.dev/
+- linkedom: https://github.com/WebReflection/linkedom
+- vitest: https://vitest.dev/

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,262 @@
+# Testing
+
+This document describes the test strategy for `11ty-subspace-builder`: what we
+test, how we test it, and what parts of the planned suite are still in flight.
+
+If you add a new test layer, change what a suite is responsible for, or change
+how tests are run, update this document in the same change.
+
+## Purpose
+
+The site now has a layered test strategy intended to protect behavior before
+and during the ongoing refactor of `eleventy.config.js`.
+
+The testing goals are:
+- lock in current site behavior before structural refactors
+- catch regressions in built output, relational timeline data, and reusable rendering
+- keep failures reviewable and deterministic
+- prefer the cheapest test layer that can prove the behavior
+
+## Current Status
+
+The suite is partially implemented and already useful.
+
+Current state:
+- tooling bootstrap is in place
+- data invariants are covered
+- contract tests cover the main rendered page types
+- snapshot tests cover several reusable components and selected full-body output
+- fixture tests cover timeline relationship and negative-path scenarios
+- `eleventy.config.js` extraction into `lib/` has started
+- unit tests have started alongside extraction work
+- Playwright smoke coverage is still planned, not finished
+
+In plan terms:
+- phases 1 through 5 are substantially complete
+- phase 6 is in progress
+- phase 7 is in progress but depends on more phase 6 extraction
+- phase 8 is still open
+
+## Test Philosophy
+
+Tests are organized by what they verify, not by what they import.
+
+Preferred order:
+1. Use the build itself for behavior that is visible in final output.
+2. Use fixtures for relational and negative-path cases that are awkward to prove against the full site.
+3. Use snapshots for small, reviewable rendering surfaces.
+4. Use unit tests for pure helpers once behavior has been extracted from `eleventy.config.js`.
+5. Use browser tests only for behavior that a DOM parser or build output cannot prove.
+
+This is intentionally biased away from broad browser automation. Most of the
+site is static, so the highest-value coverage comes from asserting built output
+and build-time data behavior directly.
+
+## Test Layers
+
+### Build
+
+`npm run build` remains the first quality gate.
+
+The build already catches some failures on its own, including:
+- broken internal links
+- invalid timeline `date` and `time` quoting
+- invalid timeline parent references
+- timeline parent cycles
+
+The rest of the suite exists to cover behavior the build does not prove well
+enough by itself.
+
+### Data Invariants
+
+Data invariant tests cover low-cost checks on data relationships and conventions
+that should fail clearly and early.
+
+Current coverage includes:
+- timeline category tag uniqueness
+- timeline category color format validation
+- `featuredTags` shape
+- `series.yaml` references resolving to real content
+
+These tests are not meant to duplicate schema failures the build already
+surfaces for routine data loading.
+
+### Contract Tests
+
+Contract tests assert behavior against the real built site output.
+
+This is the highest-value integration layer. It proves that actual generated
+pages still render the expected structure and content.
+
+Current contract coverage includes:
+- home pagination and stable listing behavior
+- about page rendering
+- notes and hidden notes behavior
+- drafts behavior
+- projects rendering and non-empty link anchors
+- timeline index and individual entry rendering
+- timeline month, week, and calendar-week archive rendering
+- timeline topic tag archives
+- tag indexes and paginated tag archives
+- series pages
+- feed generation
+- whole-site scans for unresolved templates
+- whole-site scans for empty anchors
+
+Use contract tests when the behavior is site-visible and best validated against
+the actual build, not through helper-level assertions.
+
+### Snapshots
+
+Snapshot tests are used for small, normalized HTML fragments that should remain
+easy to review in diffs.
+
+Current snapshot coverage includes:
+- project cards
+- tag chips
+- timeline entries
+- timeline week pills
+- post list items
+- a representative timeline entry body
+- a representative post body is planned and partially tracked in the suite plan
+
+Snapshots should stay narrow. If a snapshot becomes noisy or hard to review, it
+should be reduced or replaced with a more explicit assertion.
+
+### Fixtures
+
+Fixture tests use tiny Eleventy sites to exercise timeline relationships and
+negative-path build behavior in isolation.
+
+Current fixture scenarios include:
+- linear parent/child threads
+- branching threads
+- deep descendant trees
+- earlier-in-thread behavior
+- orphan parent failures
+- cycle failures
+- self-parent failures
+- tag collision failures
+- reserved slug failures
+- unquoted date failures
+- multi-category precedence behavior
+
+Use fixtures when the full site would make the scenario hard to reason about or
+when the expected outcome is a build-time throw.
+
+### Unit Tests
+
+Unit tests are for pure helpers extracted from `eleventy.config.js`.
+
+This layer is intentionally downstream of refactoring work. The suite should not
+invent artificial seams just to unit test code that is better covered through
+contract, snapshot, or fixture tests.
+
+Current visible progress:
+- `lib/timeline/refs.js` has been extracted
+- `test/unit/timeline-refs.test.js` has been added
+
+Planned unit coverage includes:
+- timeline refs
+- timeline graph traversal and descendant helpers
+- timeline relationship validation
+- timeline archive generation
+- timeline category resolution
+- excerpt generation
+- markdown code block behavior
+- TODO blockquote transformation
+- GitHub embed parsing helpers
+- link checking
+- excluded-content rules
+- asset fingerprinting
+
+### Browser Smoke
+
+A thin Playwright layer is planned for browser-only behavior.
+
+This layer is expected to stay small. It is not intended to become the primary
+test strategy for the site.
+
+Planned scope:
+- one smoke spec
+- only behaviors that require a real browser to prove
+
+## Tooling
+
+The current and planned test stack is:
+- `vitest` as the main test runner
+- `linkedom` for parsing static HTML
+- Eleventy programmatic builds for fixtures
+- Playwright for the smoke layer
+
+Supporting helpers are used to:
+- build the site once for suites that inspect `_site`
+- parse built HTML by route
+- normalize unstable output in snapshots
+
+## Test Layout
+
+The suite is organized under `test/`:
+
+```text
+test/
+  data/
+  contract/
+  fixtures/
+  snapshots/
+  unit/
+  e2e/
+  helpers/
+```
+
+Intended responsibility by directory:
+- `test/data/` for invariant checks on data conventions and references
+- `test/contract/` for assertions against the real built site
+- `test/fixtures/` for tiny isolated Eleventy scenarios
+- `test/snapshots/` for normalized HTML snapshots
+- `test/unit/` for extracted pure helpers
+- `test/e2e/` for the future Playwright smoke layer
+- `test/helpers/` for shared test utilities
+
+## Running Tests
+
+Expected local workflow:
+- run `npm run build` as the first gate
+- run `npm test` for the Vitest suite
+- use `npm run test:watch` during local iteration
+- use `npm run test:e2e` once the Playwright layer is in place
+
+While phases 6 through 8 are still underway, some parts of the documented
+structure are ahead of the completed implementation. Treat this document and
+`docs/plans/0003-test-suite.md` together: this file explains the testing model,
+while the plan tracks rollout status in detail.
+
+## Choosing the Right Test
+
+When adding coverage:
+- use a contract test if the behavior is visible in built site output
+- use a fixture if you need a tiny isolated content graph or an expected build failure
+- use a snapshot if the output fragment is stable and easy to review
+- use a unit test only after extracting a real helper with a coherent API
+- use Playwright only if the behavior genuinely needs a browser
+
+Avoid:
+- duplicating behavior across multiple layers without a strong reason
+- large unreadable snapshots
+- browser tests for behavior that static HTML assertions can already prove
+- unit tests that lock in internal implementation details before extraction is justified
+
+## What This Suite Does Not Aim To Do
+
+The current plan does not aim to provide:
+- visual regression testing
+- pixel-level OG image comparisons
+- a full accessibility sweep
+- a full HTML validation layer beyond existing build and assertion coverage
+- exhaustive schema tests for data files whose breakage the build already makes obvious
+
+## Related Documents
+
+- [Test Suite Plan](./plans/0003-test-suite.md)
+- [Testing Static Generator Projects Research](./references/testing-static-generator-projects.md)
+- [Timeline Feature](./feature-timeline.md)


### PR DESCRIPTION
## Summary
- add `docs/testing.md` describing the test strategy and test layers
- update `docs/plans/0003-test-suite.md` to reflect current rollout status
- document what is implemented now versus still planned
