### PR TITLE
[codex] persist Eleventy image cache across builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,13 +29,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Cache eleventy-fetch
+      - name: Cache Eleventy data
         uses: actions/cache@v4
         with:
           path: .cache
-          key: eleventy-fetch-${{ runner.os }}-${{ hashFiles('posts/**/*.md', 'notes/**/*.md', 'timeline/**/*.md') }}
+          key: eleventy-cache-${{ runner.os }}-${{ hashFiles('package-lock.json', 'eleventy.config.js', 'posts/**/*.md', 'notes/**/*.md', 'timeline/**/*.md', 'assets/images/**/*', 'assets/og/**/*') }}
           restore-keys: |
-            eleventy-fetch-${{ runner.os }}-
+            eleventy-cache-${{ runner.os }}-
 
       - name: Cache Playwright browsers
         id: playwright-cache

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -75,6 +75,8 @@ import {
 
 const OG_FORCE_ENV = process.env.OG_FORCE === 'true';
 const ELEVENTY_FETCH_CACHE_DIR = path.resolve('.cache');
+const ELEVENTY_IMAGE_CACHE_DIR = path.resolve('.cache/@11ty/img');
+const ELEVENTY_IMAGE_URL_PATH = '/img/';
 const SITE_DATA_URL = new URL('./_data/site.yaml', import.meta.url);
 const TIMELINE_DATA_URL = new URL('./_data/timeline.yaml', import.meta.url);
 const siteDataCache = {
@@ -230,6 +232,7 @@ const fetchTextWithCacheRecovery = async (url, options = {}, context = {}) => {
 };
 
 const isProductionBuild = process.env.ELEVENTY_ENV === 'production';
+const isServeMode = process.env.ELEVENTY_RUN_MODE === 'serve';
 
 const md = new MarkdownIt({
   html: true,
@@ -339,6 +342,8 @@ export default function (eleventyConfig) {
   eleventyConfig.addPlugin(eleventyNavigationPlugin);
   eleventyConfig.addPlugin(eleventyPluginRss);
   eleventyConfig.addPlugin(eleventyImageTransformPlugin, {
+    urlPath: ELEVENTY_IMAGE_URL_PATH,
+    outputDir: ELEVENTY_IMAGE_CACHE_DIR,
     formats: ['avif', 'webp', 'jpeg'],
     widths: [320, 640, 960, 1280],
     htmlOptions: {
@@ -349,6 +354,19 @@ export default function (eleventyConfig) {
       },
       pictureAttributes: {},
     },
+  });
+
+  eleventyConfig.on('eleventy.after', () => {
+    if (isServeMode || !fs.existsSync(ELEVENTY_IMAGE_CACHE_DIR)) {
+      return;
+    }
+
+    // Reuse cached derivatives across builds, then publish them into the final output.
+    fs.cpSync(
+      ELEVENTY_IMAGE_CACHE_DIR,
+      path.join(eleventyConfig.directories.output, ELEVENTY_IMAGE_URL_PATH),
+      { recursive: true },
+    );
   });
 
   // Tell 11ty to use our custom Markdown-it


### PR DESCRIPTION
## What changed
- moved Eleventy Img transform output into a persisted `.cache/@11ty/img` directory during builds
- copied cached derivatives back into `_site/img` in `eleventy.after` so published asset URLs stay the same
- updated the GitHub Actions `.cache` key to include Eleventy config and image inputs so cached derivatives invalidate when relevant sources change

## Why
Production builds were writing image derivatives only to `_site/img`, which is typically ephemeral in CI/deploy environments. That meant unchanged images were re-encoded on later builds instead of being reused from a warm cache.

## Impact
- first cold build populates the image cache
- later warm builds can reuse existing Eleventy Img derivatives
- local serve behavior remains unchanged because the publish copy step is skipped in serve mode

## Validation
- `npm run build`
- second `npm run build` with a warmed cache reported `26 cached` transformed images and completed significantly faster