### PR TITLE
[codex] configurable home target

### DIFF
--- a/_data/sidebarNav.yaml
+++ b/_data/sidebarNav.yaml
@@ -1,14 +1,14 @@
 ---
 - id: blog
   label: Blog
-  url: /
+  url: /blog/
   activePatterns:
     - type: equals
-      value: /
+      value: /blog/
+    - type: startsWith
+      value: /blog/
     - type: startsWith
       value: /posts/
-    - type: startsWith
-      value: /page/
 - id: notes
   label: Notes
   url: /notes/

--- a/_data/site.yaml
+++ b/_data/site.yaml
@@ -44,6 +44,10 @@ giscus:
   categoryId: DIC_kwDOOtI2P84CwAOl
   mapping: og:title
 
+# choose which sidebarNav entry renders at /
+home:
+  target: blog # id matching a sidebarNav entry whose page should render at /
+
 timeline:
   showInNav: true  # set to true to show Timeline in the sidebar nav
 

--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -290,9 +290,15 @@ layout: layouts/base.njk
     <!-- Sidebar nav: hidden on mobile until toggle; no background color -->
     <nav id="sidebar" class="dn db-ns w-100 w-25-ns pa4">
       <ul class="list pl0 ma0 pa0 flex flex-column lh-copy items-end">
+        {% set homeTargetId = site.home.target | default('blog') %}
         {% for item in sidebarNav %}
+          {% set isHomeTarget = item.id == homeTargetId %}
+          {% set itemUrl = '/' if isHomeTarget else item.url %}
           {% set activePatterns = item.activePatterns if item.activePatterns is defined else [{'type': 'equals', 'value': item.url}] %}
           {% set isActive = false %}
+          {% if isHomeTarget and currentUrl == '/' %}
+            {% set isActive = true %}
+          {% endif %}
           {% for rule in activePatterns %}
             {% if not isActive %}
               {% if rule.type == 'equals' and currentUrl == rule.value %}
@@ -309,7 +315,7 @@ layout: layouts/base.njk
               {% set displayLabel = item.label ~ ': ' ~ draftCount %}
             {% endif %}
             <li class="mb3 w-100">
-              <a href="{{ item.url }}"
+              <a href="{{ itemUrl }}"
                  class="db pa1 link dim f4 lh-copy tr tl-ns theme-text{% if isActive %} underline{% endif %}"
                  {% if isActive %}aria-current="page"{% endif %}>
                 {{ displayLabel }}

--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -11,12 +11,14 @@ layout: layouts/base.njk
 {% set autoDarkThemeId = siteThemeConfig.autoDarkId if siteThemeConfig.autoDarkId is defined else 'terminal' %}
 {% set giscusConfig = site.giscus or {} %}
 {% set currentUrl = page.url or '/' %}
-{% set isPostPage = currentUrl.indexOf('/posts/') == 0 %}
-{% set isNotePage = currentUrl.indexOf('/notes/') == 0 %}
-{% set isTimelinePage = currentUrl.indexOf('/timeline/') == 0 %}
-{% set isPostDetailPage = isPostPage and currentUrl != '/posts/' %}
-{% set isNoteDetailPage = isNotePage and currentUrl != '/notes/' %}
-{% set isTimelineDetailPage = isTimelinePage and currentUrl != '/timeline/' %}
+{% set homeTargetId = site.home.target | default('blog') %}
+{% set isHomeRoot = currentUrl == '/' %}
+{% set isPostPage = currentUrl.indexOf('/posts/') == 0 or (isHomeRoot and homeTargetId == 'blog') %}
+{% set isNotePage = currentUrl.indexOf('/notes/') == 0 or (isHomeRoot and homeTargetId == 'notes') %}
+{% set isTimelinePage = currentUrl.indexOf('/timeline/') == 0 or (isHomeRoot and homeTargetId == 'timeline') %}
+{% set isPostDetailPage = currentUrl.indexOf('/posts/') == 0 and currentUrl != '/posts/' %}
+{% set isNoteDetailPage = currentUrl.indexOf('/notes/') == 0 and currentUrl != '/notes/' %}
+{% set isTimelineDetailPage = currentUrl.indexOf('/timeline/') == 0 and currentUrl != '/timeline/' %}
 {% set isArticlePage = isPostDetailPage or isNoteDetailPage %}
 {% set showComments = comments if comments is defined else true %}
 {% set timelineEntries = collections.timeline | default([]) %}
@@ -289,39 +291,44 @@ layout: layouts/base.njk
   <div class="flex flex-column flex-row-ns">
     <!-- Sidebar nav: hidden on mobile until toggle; no background color -->
     <nav id="sidebar" class="dn db-ns w-100 w-25-ns pa4">
+      {% macro renderNavItem(item) %}
+        {% set isHomeTarget = item.id == homeTargetId %}
+        {% set itemUrl = '/' if isHomeTarget else item.url %}
+        {% set activePatterns = item.activePatterns if item.activePatterns is defined else [{'type': 'equals', 'value': item.url}] %}
+        {% set isActive = false %}
+        {% if isHomeTarget and currentUrl == '/' %}
+          {% set isActive = true %}
+        {% endif %}
+        {% for rule in activePatterns %}
+          {% if not isActive %}
+            {% if rule.type == 'equals' and currentUrl == rule.value %}
+              {% set isActive = true %}
+            {% elseif rule.type == 'startsWith' and rule.value and currentUrl.startsWith(rule.value) %}
+              {% set isActive = true %}
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+        {% if not item.hidden and not (item.id == 'drafts' and environment == 'production') and not (item.id == 'timeline' and not site.timeline.showInNav) %}
+          {% set displayLabel = item.label %}
+          {% if item.id == 'drafts' %}
+            {% set draftCount = (collections.drafts | default([])) | length %}
+            {% set displayLabel = item.label ~ ': ' ~ draftCount %}
+          {% endif %}
+          <li class="mb3 w-100">
+            <a href="{{ itemUrl }}"
+               class="db pa1 link dim f4 lh-copy tr tl-ns theme-text{% if isActive %} underline{% endif %}"
+               {% if isActive %}aria-current="page"{% endif %}>
+              {{ displayLabel }}
+            </a>
+          </li>
+        {% endif %}
+      {% endmacro %}
       <ul class="list pl0 ma0 pa0 flex flex-column lh-copy items-end">
-        {% set homeTargetId = site.home.target | default('blog') %}
         {% for item in sidebarNav %}
-          {% set isHomeTarget = item.id == homeTargetId %}
-          {% set itemUrl = '/' if isHomeTarget else item.url %}
-          {% set activePatterns = item.activePatterns if item.activePatterns is defined else [{'type': 'equals', 'value': item.url}] %}
-          {% set isActive = false %}
-          {% if isHomeTarget and currentUrl == '/' %}
-            {% set isActive = true %}
-          {% endif %}
-          {% for rule in activePatterns %}
-            {% if not isActive %}
-              {% if rule.type == 'equals' and currentUrl == rule.value %}
-                {% set isActive = true %}
-              {% elseif rule.type == 'startsWith' and rule.value and currentUrl.startsWith(rule.value) %}
-                {% set isActive = true %}
-              {% endif %}
-            {% endif %}
-          {% endfor %}
-          {% if not item.hidden and not (item.id == 'drafts' and environment == 'production') and not (item.id == 'timeline' and not site.timeline.showInNav) %}
-            {% set displayLabel = item.label %}
-            {% if item.id == 'drafts' %}
-              {% set draftCount = (collections.drafts | default([])) | length %}
-              {% set displayLabel = item.label ~ ': ' ~ draftCount %}
-            {% endif %}
-            <li class="mb3 w-100">
-              <a href="{{ itemUrl }}"
-                 class="db pa1 link dim f4 lh-copy tr tl-ns theme-text{% if isActive %} underline{% endif %}"
-                 {% if isActive %}aria-current="page"{% endif %}>
-                {{ displayLabel }}
-              </a>
-            </li>
-          {% endif %}
+          {% if item.id == homeTargetId %}{{ renderNavItem(item) }}{% endif %}
+        {% endfor %}
+        {% for item in sidebarNav %}
+          {% if item.id != homeTargetId %}{{ renderNavItem(item) }}{% endif %}
         {% endfor %}
       </ul>
     </nav>

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -343,6 +343,13 @@ export default function (eleventyConfig) {
     'environment',
     process.env.ELEVENTY_ENV || 'development',
   );
+  eleventyConfig.addGlobalData('sectionUrls', () => {
+    const target = loadSiteData()?.home?.target || 'blog';
+    const sections = ['blog', 'timeline', 'notes'];
+    return Object.fromEntries(
+      sections.map((id) => [id, id === target ? '/' : `/${id}/`]),
+    );
+  });
   eleventyConfig.addGlobalData('eleventyComputed', {
     eleventyExcludeFromCollections(data) {
       return isExcludedFromCollections(data, productionEnvironment);

--- a/src/blog.njk
+++ b/src/blog.njk
@@ -5,8 +5,8 @@ pagination:
   size: 10 # posts per page
   reverse: true
   generatePageOnEmptyData: true
-permalink: "{% if pagination.pageNumber == 0 %}/{% else %}/page/{{ pagination.pageNumber + 1 }}/{% endif %}"
 eleventyComputed:
+  permalink: "{% set base = '/' if site.home.target == 'blog' else '/blog/' %}{% if pagination.pageNumber == 0 %}{{ base }}{% else %}{{ base }}page/{{ pagination.pageNumber + 1 }}/{% endif %}"
   title: "{% if pagination.pageNumber == 0 %}{{ ui.pages.home.title }}{% else %}{{ ui.pages.home.title }} {{ ui.shared.pagination.separator }} {{ ui.shared.pagination.page }} {{ pagination.pageNumber + 1 }}{% endif %}"
 ---
 

--- a/src/notes.njk
+++ b/src/notes.njk
@@ -1,7 +1,7 @@
 ---
 layout: layouts/home.njk
-permalink: /notes/
 eleventyComputed:
+  permalink: "{{ '/' if site.home.target == 'notes' else '/notes/' }}"
   title: "{{ ui.pages.notes.title }}"
   description: "{{ ui.pages.notes.description }}"
 ---

--- a/src/timeline-calendar-weeks.njk
+++ b/src/timeline-calendar-weeks.njk
@@ -19,7 +19,7 @@ eleventyComputed:
 
 <section class="mw7">
   <p class="f6 theme-midtone mt0 mb3">
-    <a href="/timeline/">{{ timelineUi.labels.root }}</a> /
+    <a href="{{ sectionUrls.timeline }}">{{ timelineUi.labels.root }}</a> /
     <a href="/timeline/weeks/">{{ timelineUi.labels.weeks }}</a>
   </p>
   <h1 class="f3 f2-ns lh-title mt0 mb2">{{ archive.label }}</h1>

--- a/src/timeline-months-index.njk
+++ b/src/timeline-months-index.njk
@@ -14,7 +14,7 @@ eleventyComputed:
 
 <section class="mw7">
   <h1 class="f3 f2-ns lh-title mt0 mb4">
-    <a class="link dim theme-text" href="/timeline/">{{ timelineUi.labels.root }}</a>
+    <a class="link dim theme-text" href="{{ sectionUrls.timeline }}">{{ timelineUi.labels.root }}</a>
   </h1>
   <h2 class="f3 f2-ns lh-title mt0 mb2">{{ timelineUi.monthsIndex.title }}</h2>
   <p class="f6 f5-ns theme-midtone mt0 mb4">

--- a/src/timeline-months.njk
+++ b/src/timeline-months.njk
@@ -20,7 +20,7 @@ eleventyComputed:
 
 <section class="mw7">
   <p class="f6 theme-midtone mt0 mb3">
-    <a href="/timeline/">{{ timelineUi.labels.root }}</a> /
+    <a href="{{ sectionUrls.timeline }}">{{ timelineUi.labels.root }}</a> /
     <a href="/timeline/months/">{{ timelineUi.labels.months }}</a>
   </p>
   <h1 class="f3 f2-ns lh-title mt0 mb2">{{ archive.label }}</h1>

--- a/src/timeline-tags.njk
+++ b/src/timeline-tags.njk
@@ -19,7 +19,7 @@ eleventyComputed:
 
 <section class="mw7">
   <h1 class="f3 f2-ns lh-title mt0 mb4">
-    <a class="link dim theme-text" href="/timeline/">{{ timelineUi.labels.root }}</a>
+    <a class="link dim theme-text" href="{{ sectionUrls.timeline }}">{{ timelineUi.labels.root }}</a>
   </h1>
   <h2 class="f3 f2-ns lh-title mt0 mb2">#{{ archive.tag }}</h2>
   <p class="f6 f5-ns theme-midtone mt0 mb4">

--- a/src/timeline-weeks-index.njk
+++ b/src/timeline-weeks-index.njk
@@ -15,7 +15,7 @@ eleventyComputed:
 
 <section class="mw7">
   <h1 class="f3 f2-ns lh-title mt0 mb4">
-    <a class="link dim theme-text" href="/timeline/">{{ timelineUi.labels.root }}</a>
+    <a class="link dim theme-text" href="{{ sectionUrls.timeline }}">{{ timelineUi.labels.root }}</a>
   </h1>
   <h2 class="f3 f2-ns lh-title mt0 mb2">{{ timelineUi.weeksIndex.title }}</h2>
   <p class="f6 f5-ns theme-midtone mt0 mb4">

--- a/src/timeline-weeks.njk
+++ b/src/timeline-weeks.njk
@@ -19,7 +19,7 @@ eleventyComputed:
 
 <section class="mw7">
   <p class="f6 theme-midtone mt0 mb3">
-    <a href="/timeline/">{{ timelineUi.labels.root }}</a> /
+    <a href="{{ sectionUrls.timeline }}">{{ timelineUi.labels.root }}</a> /
     <a href="/timeline/months/{{ archive.monthKey }}/">{{ archive.monthLabel }}</a>
   </p>
   <h1 class="f3 f2-ns lh-title mt0 mb2">{{ archive.label }}</h1>

--- a/src/timeline.njk
+++ b/src/timeline.njk
@@ -18,7 +18,7 @@ eleventyComputed:
 
 <section class="mw7">
   <h1 class="f3 f2-ns lh-title mt0 mb4">
-    <a class="link dim theme-text" href="/timeline/">{{ timelineUi.labels.root }}</a>
+    <a class="link dim theme-text" href="{{ sectionUrls.timeline }}">{{ timelineUi.labels.root }}</a>
   </h1>
 
   {% if featuredTimelineTags | length and timelineTagArchives | length %}

--- a/src/timeline.njk
+++ b/src/timeline.njk
@@ -2,8 +2,8 @@
 layout: layouts/home.njk
 ogImage: /assets/og/timeline.png
 showPostHeader: false
-permalink: /timeline/
 eleventyComputed:
+  permalink: "{{ '/' if site.home.target == 'timeline' else '/timeline/' }}"
   title: "{{ ui.pages.timeline.title }}"
   description: "{{ ui.pages.timeline.description }}"
 ---

--- a/test/contract/home-target.test.js
+++ b/test/contract/home-target.test.js
@@ -48,6 +48,14 @@ describe('contract — site.home.target', () => {
     }
   });
 
+  it('sidebar nav lists the target item first', () => {
+    const { document } = parsePage('/');
+    const navLinks = selectAll(document, 'nav#sidebar a[href]');
+    expect(navLinks.length).toBeGreaterThan(0);
+    const firstHref = navLinks[0].getAttribute('href');
+    expect(firstHref).toBe('/');
+  });
+
   it('sidebar nav points the target item at / and others at their canonical urls', () => {
     const { document } = parsePage('/');
     const navLinks = selectAll(document, 'nav#sidebar a[href]');

--- a/test/contract/home-target.test.js
+++ b/test/contract/home-target.test.js
@@ -1,0 +1,66 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect, beforeAll } from 'vitest';
+import yaml from 'yaml';
+import {
+  ensureSiteBuilt,
+  sitePathExists,
+} from '../helpers/build-once.js';
+import { parsePage, selectAll } from '../helpers/parse.js';
+
+const HOME_ELIGIBLE = {
+  blog: '/blog/',
+  timeline: '/timeline/',
+  notes: '/notes/',
+};
+
+const readHomeTarget = () => {
+  const raw = fs.readFileSync(path.resolve('_data/site.yaml'), 'utf8');
+  const parsed = yaml.parse(raw) || {};
+  return parsed.home?.target || 'blog';
+};
+
+describe('contract — site.home.target', () => {
+  beforeAll(async () => {
+    await ensureSiteBuilt();
+  });
+
+  const target = readHomeTarget();
+
+  it('renders the configured target at /', () => {
+    expect(HOME_ELIGIBLE[target]).toBeDefined();
+    expect(sitePathExists('index.html')).toBe(true);
+  });
+
+  it('does not also emit the target at its canonical path', () => {
+    const canonical = HOME_ELIGIBLE[target].replace(/^\/+|\/+$/g, '');
+    expect(sitePathExists(`${canonical}/index.html`)).toBe(false);
+  });
+
+  it('keeps non-target home-eligible sections at their canonical paths', () => {
+    for (const [id, canonicalUrl] of Object.entries(HOME_ELIGIBLE)) {
+      if (id === target) continue;
+      const canonical = canonicalUrl.replace(/^\/+|\/+$/g, '');
+      expect(
+        sitePathExists(`${canonical}/index.html`),
+        `${id} should be emitted at ${canonicalUrl}`,
+      ).toBe(true);
+    }
+  });
+
+  it('sidebar nav points the target item at / and others at their canonical urls', () => {
+    const { document } = parsePage('/');
+    const navLinks = selectAll(document, 'nav#sidebar a[href]');
+    const hrefById = new Map();
+    for (const a of navLinks) {
+      const text = (a.textContent || '').trim().toLowerCase();
+      hrefById.set(text.split(/[\s:]/)[0], a.getAttribute('href'));
+    }
+    expect(hrefById.get(target)).toBe('/');
+    for (const [id, canonicalUrl] of Object.entries(HOME_ELIGIBLE)) {
+      if (id === target) continue;
+      if (!hrefById.has(id)) continue;
+      expect(hrefById.get(id)).toBe(canonicalUrl);
+    }
+  });
+});


### PR DESCRIPTION
## What changed
- add `site.home.target` configuration so the home navigation entry can point at a configurable page target
- rename the blog landing template from `src/index.njk` to `src/blog.njk` and update related routes/templates to use the new target-aware links
- fix home target section styling, internal links, and nav ordering regressions
- add contract coverage for configurable home target behavior

## Why
This lets the site choose a different home target without hardcoding the blog landing page, while keeping navigation and internal links coherent when that target changes.

## Impact
Users can route the home entry to the configured target consistently across the site. Developers get contract tests that protect the target-aware behavior and related link generation.

## Validation
- `npm run build`
